### PR TITLE
Fix #26, #49: Duplicate on broadcast

### DIFF
--- a/argon/src/argon/Data.scala
+++ b/argon/src/argon/Data.scala
@@ -1,7 +1,7 @@
 package argon
 
 import forge.tags._
-import argon.transform.Transformer
+import argon.transform.TransformerInterface
 
 import scala.collection.mutable
 
@@ -69,7 +69,7 @@ object Transfer extends Enumeration {
   * metadata is created.
   */
 abstract class Data[T](val transfer: Transfer.Transfer) { self =>
-  final type Tx = Transformer
+  final type Tx = TransformerInterface
 
   type Transfer = Transfer.Transfer
 

--- a/argon/src/argon/Op.scala
+++ b/argon/src/argon/Op.scala
@@ -1,7 +1,7 @@
 package argon
 
 import Freq._
-import argon.transform.Transformer
+import argon.transform.TransformerInterface
 import forge.tags.rig
 
 /** Any staged operation.
@@ -11,7 +11,7 @@ import forge.tags.rig
   * NOTE: Op is NOT covariant with R - strange things happen with pattern matching if it is.
   */
 abstract class Op[R:Type] extends Serializable with Product {
-  final type Tx = Transformer
+  final type Tx = TransformerInterface
   val R: Type[R] = Type[R]
   def name: String = productPrefix
 

--- a/argon/src/argon/tags/Arith.scala
+++ b/argon/src/argon/tags/Arith.scala
@@ -1,17 +1,17 @@
-package spatial.tags
+package argon.tags
+
+import utils.tags.MacroUtils
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
-
-import utils.tags.MacroUtils
 
 class Arith[Ctx <: blackbox.Context](override val c: Ctx) extends TypeclassMacro[Ctx](c) {
   import c.universe._
 
   def implement(cls: ClassDef, obj: ModuleDef, fields: Seq[ValDef]): (ClassDef, ModuleDef) = {
     val utils = new MacroUtils[c.type](c)
-    import utils._
     import c.universe._
+    import utils._
 
     val fieldTypes = fields.map(_.tpTree)
     val fieldNames = fields.map(_.name)

--- a/argon/src/argon/tags/Bits.scala
+++ b/argon/src/argon/tags/Bits.scala
@@ -1,17 +1,17 @@
-package spatial.tags
+package argon.tags
+
+import utils.tags.MacroUtils
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
-
-import utils.tags.MacroUtils
 
 class Bits[Ctx <: blackbox.Context](override val c: Ctx) extends TypeclassMacro[Ctx](c) {
   import c.universe._
 
   def implement(cls: ClassDef, obj: ModuleDef, fields: Seq[ValDef]): (ClassDef, ModuleDef) = {
     val utils = new MacroUtils[c.type](c)
-    import utils._
     import c.universe._
+    import utils._
 
     val fieldTypes = fields.map(_.tpTree)
     val fieldNames = fields.map(_.name)

--- a/argon/src/argon/tags/Structs.scala
+++ b/argon/src/argon/tags/Structs.scala
@@ -1,10 +1,10 @@
-package spatial.tags
+package argon.tags
+
+import utils.tags.MacroUtils
 
 import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
-
-import utils.tags.MacroUtils
 
 /** Annotation class for @struct macro annotation. */
 final class struct extends StaticAnnotation {
@@ -33,8 +33,8 @@ object StagedStructsMacro {
     )
 
     val utils = new MacroUtils[c.type](c)
-    import utils._
     import c.universe._
+    import utils._
 
     val (cls,obj) = annottees.toList match {
       case List(cd: ClassDef, md: ModuleDef) => (cd,md)

--- a/argon/src/argon/transform/Transformer.scala
+++ b/argon/src/argon/transform/Transformer.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable
   *   Mirror - Create a recursive copy of a value with substitutions
   *   Update - Modify the existing value with substitutions
   */
-abstract class Transformer extends Pass {
+abstract class Transformer extends Pass with TransformerInterface {
   protected val f: Transformer = this
 
   /** Helper method for performing substitutions within pattern matching. */

--- a/argon/src/argon/transform/TransformerInterface.scala
+++ b/argon/src/argon/transform/TransformerInterface.scala
@@ -1,0 +1,5 @@
+package argon.transform
+
+trait TransformerInterface {
+  def apply[T](x: T): T
+}

--- a/build.sbt
+++ b/build.sbt
@@ -63,10 +63,9 @@ lazy val templateResources   = (project in file("./resources/synth/chisel-templa
 lazy val models = project.settings(common)
 lazy val forge  = project.settings(common).dependsOn(utils)
 lazy val poly   = project.settings(common).dependsOn(utils)
-lazy val argon  = project.settings(common).dependsOn(forge, emul)
-lazy val spatialTags = project.settings(common).dependsOn(utils, forge)
+lazy val argon  = project.settings(common).dependsOn(utils, forge, emul)
 
-lazy val nova = (project in file(".")).settings(common).dependsOn(forge, emul, argon, models, poly, spatialTags)
+lazy val nova = (project in file(".")).settings(common).dependsOn(forge, emul, argon, models, poly)
 lazy val apps = project.settings(common).dependsOn(nova)
 
 /** Set number of threads for testing **/

--- a/forge/src/forge/EmbeddedControls.scala
+++ b/forge/src/forge/EmbeddedControls.scala
@@ -1,8 +1,8 @@
 package forge
 
-import language.experimental.macros
 import scala.reflect.{ClassTag,classTag}
 import scala.reflect.macros.whitebox
+import scala.language.experimental.macros
 
 /**
   * Default implementation of Scala control structures.

--- a/src/pir/lang/Aliases.scala
+++ b/src/pir/lang/Aliases.scala
@@ -1,4 +1,4 @@
-package pir.lang.static
+package pir.lang
 
 // No aliases of the form type X = pir.lang.X (creates a circular reference)
 // Everything else is ok.

--- a/src/pir/lang/static/Statics.scala
+++ b/src/pir/lang/static/Statics.scala
@@ -1,5 +1,7 @@
 package pir.lang.static
 
+import pir.lang.{ExternalAliases, InternalAliases}
+
 trait Statics extends Pointers
 
 /** Internal view of PIR */

--- a/src/spatial/Spatial.scala
+++ b/src/spatial/Spatial.scala
@@ -197,6 +197,8 @@ trait Spatial extends Compiler {
     cli.note("")
     cli.note("Experimental:")
 
+    cli.opt[Unit]("broadcast").action{(_,_) => spatialConfig.enableBroadcast = true }.text("Enable broadcast reads")
+
     cli.opt[Unit]("asyncMem").action{(_,_) => spatialConfig.enableAsyncMem = true }.text("Enable asynchronous memories")
 
     cli.opt[Int]("compressWires").action{(t,_) => spatialConfig.compressWires = t }.text("Enable string compression on chisel wires to shrink JVM bytecode")

--- a/src/spatial/SpatialConfig.scala
+++ b/src/spatial/SpatialConfig.scala
@@ -39,6 +39,8 @@ class SpatialConfig extends Config {
   var enableAsyncMem = false
   var enableRetiming = true
 
+  var enableBroadcast = false // Allow broadcasting reads
+
   // Internal flag used to mark whether unit pipe transformer has been run or not
   var allowPrimitivesInOuterControl = true
 

--- a/src/spatial/dsl.scala
+++ b/src/spatial/dsl.scala
@@ -1,8 +1,11 @@
 package spatial
 
+import argon.tags.StagedStructsMacro
+
 trait SpatialDSL extends lang.api.StaticAPI_Frontend
 
-object libview extends SpatialDSL {
+/** A "library" view of the Spatial DSL without any Scala name shadowing. */
+object libdsl extends SpatialDSL {
   import language.experimental.macros
   import scala.annotation.StaticAnnotation
   import forge.tags.AppTag
@@ -14,10 +17,11 @@ object libview extends SpatialDSL {
   private object spatial extends AppTag("spatial", "SpatialApp")
 
   final class struct extends StaticAnnotation {
-    def macroTransform(annottees: Any*): Any = macro tags.StagedStructsMacro.impl
+    def macroTransform(annottees: Any*): Any = macro StagedStructsMacro.impl
   }
 }
 
+/** A full view of the Spatial DSL, including shadowing of Scala names. */
 object dsl extends SpatialDSL with lang.api.StaticAPI_Shadowing {
   import language.experimental.macros
   import scala.annotation.StaticAnnotation
@@ -30,6 +34,6 @@ object dsl extends SpatialDSL with lang.api.StaticAPI_Shadowing {
   private object spatial extends AppTag("spatial", "SpatialApp")
 
   final class struct extends StaticAnnotation {
-    def macroTransform(annottees: Any*): Any = macro tags.StagedStructsMacro.impl
+    def macroTransform(annottees: Any*): Any = macro StagedStructsMacro.impl
   }
 }

--- a/src/spatial/lang/Bus.scala
+++ b/src/spatial/lang/Bus.scala
@@ -1,8 +1,8 @@
 package spatial.lang
 
 import argon.Mirrorable
+import argon.tags.struct
 import forge.tags._
-import spatial.tags._
 
 case class Pin(name: String) {
   override def toString: String = name

--- a/src/spatial/metadata/access/AffineData.scala
+++ b/src/spatial/metadata/access/AffineData.scala
@@ -39,6 +39,8 @@ case class AccessMatrix(
   override def toString: String = {
     stm(access) + " {" + unroll.mkString(",") + "}\n" + matrix.toString
   }
+
+  def short: String = s"$access {${unroll.mkString(",")}}"
 }
 
 /** The unrolled access patterns of an optionally parallelized memory access represented as affine matrices.

--- a/src/spatial/metadata/access/package.scala
+++ b/src/spatial/metadata/access/package.scala
@@ -79,6 +79,27 @@ package object access {
     }
   }
 
+  /*implicit class AccessMatrixOps(a: AccessMatrix) {
+    /** True if a and b always occur at the exact same time.
+      * This is trivially true if a and b are the same unrolled access.
+      *
+      * This method is used to enable broadcast reads.
+      */
+    def isLockstepWith(b: AccessMatrix, mem: Sym[_]): Boolean = {
+      if (a.access != b.access || a.matrix != b.matrix) return false
+
+      val iters = accessIterators(a.access, mem)
+      // The index of the outermost iterator which will differ between a and b
+      val outer = a.unroll.indices.find{i => a.unroll(i) != b.unroll(i) }
+      if (outer.isDefined) {
+        val outerIter = iters(outer.get)
+        // The outermost control parallelized over a and b
+        val ctrl = outerIter.parent
+      }
+      else true // a and b are identical - they are trivially lockstep
+    }
+  }*/
+
   implicit class AccessOps(a: Sym[_]) {
 
     def isParEnq: Boolean = a.op.exists(_.isParEnq)
@@ -140,6 +161,7 @@ package object access {
       else if (distA < 0 && distB < 0) { distA < distB && ctrlA.willRunMultiple && a.mustOccurWithin(ctrlAB) } // p b a
       else false
     }
+
 
     def accessWidth: Int = a match {
       case Op(_:RegFileShiftIn[_,_])        => 1

--- a/src/spatial/metadata/access/package.scala
+++ b/src/spatial/metadata/access/package.scala
@@ -79,29 +79,6 @@ package object access {
     }
   }
 
-  implicit class AccessMatrixOps(a: AccessMatrix) {
-    /** True if a and b always occur at the exact same time.
-      * This is trivially true if a and b are the same unrolled access.
-      *
-      * This method is used to enable broadcast reads.
-      */
-    @stateful def isLockstepWith(b: AccessMatrix, mem: Sym[_]): Boolean = {
-      // TODO[3]: What about accesses of the same form across different loops?
-      if (a.access != b.access || a.matrix != b.matrix) return false
-
-      val iters = accessIterators(a.access, mem)
-      // The index of iterators which will differ between a and b
-      // If this list is empty, a and b are identical (so they are trivially lockstep)
-      val differ = a.unroll.indices.filter{i => a.unroll(i) != b.unroll(i) }
-      val itersDiffer = differ.map{i => iters(i) }
-      if (itersDiffer.nonEmpty) {
-        val outer = itersDiffer.head
-        outer.isLockstepAcross(itersDiffer, Some(a.access))
-      }
-      else true
-    }
-  }
-
   implicit class AccessOps(a: Sym[_]) {
 
     def isParEnq: Boolean = a.op.exists(_.isParEnq)

--- a/src/spatial/metadata/control/ControlData.scala
+++ b/src/spatial/metadata/control/ControlData.scala
@@ -162,4 +162,3 @@ case class WrittenMems(mems: Set[Sym[_]]) extends Data[WrittenMems](SetBy.Flow.S
   * Default: empty set
   */
 case class ReadMems(mems: Set[Sym[_]]) extends Data[ReadMems](SetBy.Flow.Self)
-

--- a/src/spatial/metadata/control/package.scala
+++ b/src/spatial/metadata/control/package.scala
@@ -54,6 +54,8 @@ package object control {
       case _ => false
     }
 
+    def isFSM: Boolean = op.isInstanceOf[StateMachine[_]]
+
     def isStreamLoad: Boolean = op match {
       case _:FringeDenseLoad[_,_] => true
       case _ => false
@@ -86,6 +88,7 @@ package object control {
     def isBranch: Boolean = op.exists(_.isBranch)
     def isParallel: Boolean = op.exists(_.isParallel)
     def isUnitPipe: Boolean = op.exists(_.isUnitPipe)
+    def isFSM: Boolean = op.exists(_.isFSM)
 
     def isMemReduce: Boolean = op.exists(_.isMemReduce)
 
@@ -237,6 +240,7 @@ package object control {
       case _:EnPrimitive[_] | _:EnControl[_] => true
       case _ => false
     }
+
 
     // --- Control hierarchy --- //
 
@@ -443,6 +447,7 @@ package object control {
 
     def userII: Option[Double] = metadata[UserII](s).map(_.interval)
     def userII_=(interval: Option[Double]): Unit = interval.foreach{ii => metadata.add(s, UserII(ii)) }
+
   }
 
 

--- a/src/spatial/metadata/control/package.scala
+++ b/src/spatial/metadata/control/package.scala
@@ -316,6 +316,21 @@ package object control {
       }
     }
 
+    def writtenMems: Set[Sym[_]] = {
+      s.flatMap{sym => metadata[WrittenMems](sym).map(_.mems) }.getOrElse(Set.empty)
+    }
+    def writtenMems_=(mems: Set[Sym[_]]): Unit = {
+      s.foreach{sym => metadata.add(sym, WrittenMems(mems)) }
+    }
+
+    def readMems: Set[Sym[_]] = {
+      s.flatMap{sym => metadata[ReadMems](sym).map(_.mems) }.getOrElse(Set.empty)
+    }
+    def readMems_=(mems: Set[Sym[_]]): Unit = {
+      s.foreach{sym => metadata.add(sym, ReadMems(mems)) }
+    }
+
+
 
     // --- Streaming Controllers --- //
     def listensTo: List[StreamInfo] = {
@@ -447,11 +462,6 @@ package object control {
     def userSchedule: CtrlSchedule = getUserSchedule.getOrElse{throw new Exception(s"Undefined user schedule for $s") }
     def userSchedule_=(sched: CtrlSchedule): Unit = metadata.add(s, UserScheduleDirective(sched))
 
-    def writtenMems: Set[Sym[_]] = metadata[WrittenMems](s).map(_.mems).getOrElse(Set.empty)
-    def writtenMems_=(mems: Set[Sym[_]]): Unit = metadata.add(s, WrittenMems(mems))
-
-    def readMems: Set[Sym[_]] = metadata[ReadMems](s).map(_.mems).getOrElse(Set.empty)
-    def readMems_=(mems: Set[Sym[_]]): Unit = metadata.add(s, ReadMems(mems))
 
     // --- Control Hierarchy --- //
 

--- a/src/spatial/node/HierarchyUnrolled.scala
+++ b/src/spatial/node/HierarchyUnrolled.scala
@@ -39,6 +39,21 @@ abstract class UnrolledAccessor[A:Type,R:Type] extends EnPrimitive[R] {
   }
 }
 
+object UnrolledReader {
+  def unapply(x: Op[_]): Option[UnrolledRead] = x match {
+    case a: UnrolledAccessor[_,_] => a.unrolledRead
+    case _ => None
+  }
+  def unapply(x: Sym[_]): Option[UnrolledRead] = x.op.flatMap(UnrolledReader.unapply)
+}
+object UnrolledWriter {
+  def unapply(x: Op[_]): Option[UnrolledWrite] = x match {
+    case a: UnrolledAccessor[_,_] => a.unrolledWrite
+    case _ => None
+  }
+  def unapply(x: Sym[_]): Option[UnrolledWrite] = x.op.flatMap(UnrolledWriter.unapply)
+}
+
 /** Banked accessors */
 abstract class BankedAccessor[A:Type,R:Type] extends UnrolledAccessor[A,R] {
   def bank: Seq[Seq[Idx]]

--- a/src/spatial/traversal/banking/MemoryConfigurer.scala
+++ b/src/spatial/traversal/banking/MemoryConfigurer.scala
@@ -123,12 +123,16 @@ class MemoryConfigurer[+C[_]](mem: Mem[_,C], strategy: BankingStrategy)(implicit
     dbgs(s"  Grouping ${accesses.size} ${tp}s: ")
 
     accesses.foreach{a =>
-      dbg(s"    Access: ${a.access} [${a.parent}]")
+      dbg(s"    Access: ${a.access} {${a.unroll.mkString(",")}} [${a.parent}]")
       val grpId = {
         if (a.parent == Ctrl.Host) { if (groups.isEmpty) -1 else 0 }
         else groups.zipWithIndex.indexWhere{case (grp, i) =>
-          // Filter for accesses that require concurrent port access AND either don't overlap or are identical.  Should drop in data broadcasting node in this case
-          val pairs = grp.filter{b => requireConcurrentPortAccess(a, b) && (!a.overlapsAddress(b) | ((a.access == b.access) && (a.matrix == b.matrix)))  }
+          // Filter for accesses that require concurrent port access AND either don't overlap or are identical.
+          // Should drop in data broadcasting node in this case
+          val pairs = grp.filter{b =>
+            requireConcurrentPortAccess(a, b) &&
+            (!a.overlapsAddress(b) | ((a.access == b.access) && (a.matrix == b.matrix)))
+          }
           if (pairs.nonEmpty) dbg(s"      Group #$i: ")
           else                dbg(s"      Group #$i: <none>")
           pairs.foreach{b => dbgs(s"        ${b.access} [${b.parent}]") }

--- a/test/pir/test/PIRTests.scala
+++ b/test/pir/test/PIRTests.scala
@@ -1,6 +1,6 @@
 package pir.test
 
-import spatial.libview._
+import spatial.libdsl._
 import pir.dsl._
 import _root_.pir.PIRTest
 

--- a/test/spatial/tests/feature/banking/BankNonbuffered.scala
+++ b/test/spatial/tests/feature/banking/BankNonbuffered.scala
@@ -1,0 +1,46 @@
+package spatial.tests.feature.banking
+
+import argon.Block
+import spatial.dsl._
+
+/** Simple test case for using a single SRAM (x) across two stages of a metapipeline
+  * where the SRAM itself does not need to be buffered for the pipeline.
+  */
+@spatial class BankNonbuffered extends SpatialTest {
+
+  def main(args: Array[String]): Unit = {
+    val dram = DRAM[Float](32)
+    val array = Array.tabulate(32){i => random[Float] }
+    setMem(dram, array)
+
+    val out_ceil  = DRAM[Float](32)
+    val out_floor = DRAM[Float](32)
+
+    Accel {
+      val x = SRAM[Float](32)
+      val y = SRAM[Float](32)
+      val z = SRAM[Float](32)
+      x load dram
+
+      Foreach(0 until 32){i =>
+        Pipe{ y(i) = ceil(x(i)) }   // These reads on x should either be broadcasted
+        Pipe{ z(i) = floor(x(i)) }  // or correspond to 2 separate instances
+      }
+
+      out_ceil store y
+      out_floor store z
+    }
+
+    val gold_ceil  = array.map{x => ceil(x) }
+    val gold_floor = array.map{x => floor(x) }
+    assert(gold_ceil == getMem(out_ceil))
+    assert(gold_floor == getMem(out_floor))
+  }
+
+  override def checkIR(block: Block[_]): Result = {
+    import spatial.metadata.memory._
+    val xs = LocalMemories.all.filter(_.name.exists{_.startsWith("x")})
+    xs.forall(_.instance.depth == 1) &&
+      xs.forall{x => x.readers.map{read => read.ports(0).values.head.muxPort }.size == 1 }
+  }
+}

--- a/utils/src/utils/Testbench.scala
+++ b/utils/src/utils/Testbench.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FlatSpecLike,Matchers}
 trait Testbench extends FlatSpecLike with Matchers {
   type Result = utils.Result
   type Error = Result.Error
+  implicit def resultToBoolean(x: Boolean): Result = if (x) Pass else Fail
   lazy val Pass: Result = Result.Pass
   lazy val Fail: Result = Result.Fail
   lazy val Unknown: Result = Result.Unknown

--- a/utils/src/utils/implicits/collections.scala
+++ b/utils/src/utils/implicits/collections.scala
@@ -84,6 +84,26 @@ object collections {
     def pairs: Iterator[(A,A)] = {
       if (x.size >= 2) (x.tail.iterator.map{m1 => (x.head,m1) } ++ x.tail.pairs) else Iterator.empty
     }
+
+    def mapFind[B](func: A => Option[B]): Option[B] = {
+      var res: Option[B] = None
+      val iter = x.iterator
+      while (res.isEmpty && iter.hasNext) {
+        res = func(iter.next())
+      }
+      res
+    }
+  }
+
+  implicit class IteratorHelpers[A](x: Iterator[A]) {
+    def mapFind[B](func: A => Option[B]): Option[B] = {
+      var res: Option[B] = None
+      val iter = x
+      while (res.isEmpty && iter.hasNext) {
+        res = func(iter.next())
+      }
+      res
+    }
   }
 
   implicit class HashMapOps[K,V](map: mutable.Map[K,V]) {


### PR DESCRIPTION
Fixes TwoDuplicatesPachinko, but creates two instances for sram

First step in adding broadcast support (currently enableBroadcast will produce illegal behavior)

(Also removes spatialTags module in favor of creating a package in argon)