### PR TITLE
Issue75 excessive wires

### DIFF
--- a/resources/regression/synth_launcher.sh
+++ b/resources/regression/synth_launcher.sh
@@ -38,11 +38,12 @@ if [[ ! -f ${REGRESSION_HOME}/lock ]]; then
 	git clone git@github.com:stanford-ppl/spatial
 	git clone git@github.com:stanford-ppl/test-data.git
 	cd spatial
-	export apphash="nova-spatial"
+	export 
+	export branchname=`git rev-parse --abbrev-ref HEAD | sed -i "s/HEAD/unknown/g"`
 	export hash=`git rev-parse HEAD`
 	export timestamp=`git show -s --format=%ci`
 	echo $hash > ${REGRESSION_HOME}/data/hash
-	echo $apphash > ${REGRESSION_HOME}/data/apphash
+	echo $branchname > ${REGRESSION_HOME}/data/branchname
 	echo $timestamp > ${REGRESSION_HOME}/data/timestamp
 
 	# Run tests

--- a/resources/regression/synth_regression.sh
+++ b/resources/regression/synth_regression.sh
@@ -13,36 +13,36 @@ if [[ $1 = "zynq" ]]; then
 	export CLOCK_FREQ_MHZ=125
 	# Prep the spreadsheet
 	cd ${REGRESSION_HOME}
-	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$apphash" "$timestamp" "Zynq"`
+	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$branchname" "$timestamp" "Zynq"`
 elif [[ $1 = "zcu" ]]; then
 	export PIR_HOME=${REGRESSION_HOME}
 	export CLOCK_FREQ_MHZ=100
 	# Prep the spreadsheet
 	cd ${REGRESSION_HOME}
-	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$apphash" "$timestamp" "ZCU"`
+	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$branchname" "$timestamp" "ZCU"`
 elif [[ $1 = "arria10" ]]; then
 	export PIR_HOME=${REGRESSION_HOME}
 	export CLOCK_FREQ_MHZ=125
 	# Prep the spreadsheet
 	cd ${REGRESSION_HOME}
-	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$apphash" "$timestamp" "Arria10"`
+	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$branchname" "$timestamp" "Arria10"`
 elif [[ $1 = "aws" ]]; then
 	export PIR_HOME=${REGRESSION_HOME}
 	export CLOCK_FREQ_MHZ=250
 	# Prep the spreadsheet
 	cd ${REGRESSION_HOME}
-	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$apphash" "$timestamp" "AWS"`
+	tid=`python3 ${REGRESSION_HOME}/next-spatial/spatial/resources/regression/gdocs.py "prepare_sheet" "$hash" "$branchname" "$timestamp" "AWS"`
 fi
 
 echo $tid > ${REGRESSION_HOME}/data/tid
 echo $hash > ${REGRESSION_HOME}/data/hash
-echo $apphash > ${REGRESSION_HOME}/data/ahash
+echo $branchname > ${REGRESSION_HOME}/data/branchname
 ls ${REGRESSION_HOME}
 ls ${REGRESSION_HOME}/next-spatial
 echo $hash
 echo $tid > ${REGRESSION_HOME}/next-spatial/spatial/tid
 echo $hash > ${REGRESSION_HOME}/next-spatial/spatial/hash
-echo $apphash > ${REGRESSION_HOME}/next-spatial/spatial/ahash
+echo $branchname > ${REGRESSION_HOME}/next-spatial/spatial/branchname
 
 export PATH=/usr/bin:/local/ssd/home/mattfel/aws-fpga/hdk/common/scripts:/opt/Xilinx/SDx/2017.1/Vivado/bin:/opt/Xilinx/SDx/2017.1/SDK/bin:/opt/Xilinx/Vivado/2017.1/bin:/opt/Xilinx/SDK/2017.1/bin:$PATH
 export LM_LICENSE_FILE=1717@cadlic0.stanford.edu:7195@cadlic0.stanford.edu:7193@cadlic0.stanford.edu:/opt/Xilinx/awsF1.lic:27000@cadlic0.stanford.edu:$LM_LICENSE_FILE

--- a/resources/synth/chisel-templates/scripts/regression_run.sh
+++ b/resources/synth/chisel-templates/scripts/regression_run.sh
@@ -27,7 +27,7 @@ if [[ $GDOCS -eq 1 ]]; then
 
 	# Hacky go back until $SPATIAL_HOME
 	hash=`cat ${basepath}/reghash`
-	ahash=nova-spatial
+	branchname=`cat ${basepath}/branchname`
 	#appname=`basename \`pwd\``
 	fullname=`cat chisel/IOModule_1.scala | grep "Root controller for app" | sed "s/.*: //g"`
 	testdirs=`find ${basepath}/test -type d -printf '%d\t%P\n' | sort -r -nk1 | cut -f2- | grep -v target | sed "s/.*\///g"`
@@ -38,7 +38,7 @@ if [[ $GDOCS -eq 1 ]]; then
 	appname=$fullname
 	properties=`cat chisel/IOModule_1.scala | grep "App Characteristics" | sed "s/^.*App Characteristics: //g" | sed "s/ //g"`
 
-	python3 ${basepath}/resources/regression/gdocs.py "report_regression_results" $1 $appname $pass $runtime $hash $ahash "$properties" "$2 $3 $4 $5 $6 $7 $8 $9"
+	python3 ${basepath}/resources/regression/gdocs.py "report_regression_results" $1 $appname $pass $runtime $hash $branchname "$properties" "$2 $3 $4 $5 $6 $7 $8 $9"
 
 fi
 

--- a/resources/synth/chisel-templates/scripts/scrape.sh
+++ b/resources/synth/chisel-templates/scripts/scrape.sh
@@ -14,7 +14,7 @@ elif [[ $1 = "AWS" ]]; then
 fi
 
 hash=`cat ${REGRESSION_HOME}/current-spatial/spatial/hash`
-ahash=`cat ${REGRESSION_HOME}/current-spatial/spatial/ahash`
+branchname=`cat ${REGRESSION_HOME}/current-spatial/spatial/branchname`
 
 #appname=`basename \`pwd\``
 fullname=`cat chisel/IOModule_1.scala | grep "Root controller for app" | sed "s/.*: //g"`
@@ -113,7 +113,7 @@ fi
 synthtime=$((endtime-starttime))
 
 echo "LUT: $lutraw (${lutpcnt}%) Regs: $regraw (${regpcnt}%) BRAM: $ramraw (${rampcnt}%) URAM: $uramraw (${urampcnt}%) DSP: $dspraw (${dsppcnt}%) LaL: $lalraw (${lalpcnt}%) LaM: $lamraw (${lampcnt}%) Synthtime: $synthtime Tmg_Met: $tmg $1"
-python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_synth_results" $appname "$lutraw (${lutpcnt}%)" "$regraw (${regpcnt}%)" "$ramraw (${rampcnt}%)" "$uramraw (${urampcnt}%)" "$dspraw (${dsppcnt}%)" "$lalraw (${lalpcnt}%)" "$lamraw (${lampcnt}%)" "$synthtime" "$tmg" "$1" "$hash" "$ahash"
+python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_synth_results" $appname "$lutraw (${lutpcnt}%)" "$regraw (${regpcnt}%)" "$ramraw (${rampcnt}%)" "$uramraw (${urampcnt}%)" "$dspraw (${dsppcnt}%)" "$lalraw (${lalpcnt}%)" "$lamraw (${lampcnt}%)" "$synthtime" "$tmg" "$1" "$hash" "$branchname"
 
 
 # Run on board
@@ -143,7 +143,7 @@ if [[ $1 = "Zynq" ]]; then
     runtime=`cat log | grep "ran for" | head -1 | sed "s/^.*ran for //g" | sed "s/ ms, .*$//g"`
     if [[ $runtime = "" ]]; then runtime=NA; fi
     pass=`if [[ $(cat log | grep "Assertion" | wc -l) -gt 0 ]]; then echo FAILED; else echo Passed!; fi`
-    python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_board_runtime" $appname $timeout $runtime $pass "$2 $3 $4 $5 $6 $7 $8" "$1" "$locked" "$hash" "$ahash"
+    python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_board_runtime" $appname $timeout $runtime $pass "$2 $3 $4 $5 $6 $7 $8" "$1" "$locked" "$hash" "$branchname"
 elif [[ $1 = "ZCU" ]]; then
 	APP=$(basename $(pwd))
 	scp $(basename $(pwd)).tar.gz root@holodeck-zcu102:
@@ -170,7 +170,7 @@ elif [[ $1 = "ZCU" ]]; then
     runtime=`cat log | grep "ran for" | head -1 | sed "s/^.*ran for //g" | sed "s/ ms, .*$//g"`
     if [[ $runtime = "" ]]; then runtime=NA; fi
     pass=`if [[ $(cat log | grep "Assertion" | wc -l) -gt 0 ]]; then echo FAILED; else echo Passed!; fi`
-    python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_board_runtime" $appname $timeout $runtime $pass "$2 $3 $4 $5 $6 $7 $8" "$1" "$locked" "$hash" "$ahash"	
+    python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_board_runtime" $appname $timeout $runtime $pass "$2 $3 $4 $5 $6 $7 $8" "$1" "$locked" "$hash" "$branchname"	
 elif [[ $1 = "Arria10" ]]; then
 	APP=$(basename $(pwd))
 	scp $(basename $(pwd)).tar.gz root@arria10:   # TODO: Tian (fill in whatever you need to scp and execute the app on the board)
@@ -193,7 +193,7 @@ elif [[ $1 = "Arria10" ]]; then
     runtime=`cat log | grep "ran for" | head -1 | sed "s/^.*ran for //g" | sed "s/ ms, .*$//g"`
     if [[ $runtime = "" ]]; then runtime=NA; fi
     pass=`if [[ $(cat log | grep "Assertion" | wc -l) -gt 0 ]]; then echo FAILED; else echo Passed!; fi`
-    python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_board_runtime" $appname $timeout $runtime $pass "$2 $3 $4 $5 $6 $7 $8" "$1" "$locked" "$hash" "$ahash"	
+    python3 ${REGRESSION_HOME}/current-spatial/spatial/resources/regression/gdocs.py "report_board_runtime" $appname $timeout $runtime $pass "$2 $3 $4 $5 $6 $7 $8" "$1" "$locked" "$hash" "$branchname"	
 fi
 
 # Fake out regression

--- a/resources/synth/chisel-templates/templates/Accum.scala
+++ b/resources/synth/chisel-templates/templates/Accum.scala
@@ -34,10 +34,10 @@ class FixFMAAccum(val cycleLatency: Double, val fmaLatency: Double, val s: Boole
     fixadd.r := acc.io.output.data(0)
     val result = Wire(new FixedPoint(s,d,f))
     Utils.FixFMA(fixin1, fixin2, fixadd, fmaLatency.toInt, true.B).cast(result)
-    acc.io.xBarW(0).data := result.r
-    acc.io.xBarW(0).en := Utils.getRetimed(io.enable & dispatchLane === lane, fmaLatency.toInt)
-    acc.io.xBarW(0).reset := io.reset
-    acc.io.xBarW(0).init := initBits
+    acc.io.xBarW(0).data.head := result.r
+    acc.io.xBarW(0).en.head := Utils.getRetimed(io.enable & dispatchLane === lane, fmaLatency.toInt)
+    acc.io.xBarW(0).reset.head := io.reset
+    acc.io.xBarW(0).init.head := initBits
   }
 
   io.output := Utils.getRetimed(accums.map(_._1.io.output.data(0)).reduce{_+_}, (Utils.log2Up(cycleLatency).toDouble).toInt).r // TODO: Please build tree and retime appropriately
@@ -71,10 +71,10 @@ class FixAddAccum(val cycleLatency: Double, val addLatency: Double, val s: Boole
     val fixadd = Wire(new FixedPoint(s,d,f))
     fixadd.r := acc.io.output.data(0)
     val result = Wire(new FixedPoint(s,d,f))
-    acc.io.xBarW(0).data := (fixadd + fixin1).r
-    acc.io.xBarW(0).en := Utils.getRetimed(io.enable & dispatchLane === lane, addLatency.toInt)
-    acc.io.xBarW(0).reset := io.reset
-    acc.io.xBarW(0).init := initBits
+    acc.io.xBarW(0).data.head := (fixadd + fixin1).r
+    acc.io.xBarW(0).en.head := Utils.getRetimed(io.enable & dispatchLane === lane, addLatency.toInt)
+    acc.io.xBarW(0).reset.head := io.reset
+    acc.io.xBarW(0).init.head := initBits
   }
 
   io.output := Utils.getRetimed(accums.map(_._1.io.output.data(0)).reduce{_+_}, (Utils.log2Up(cycleLatency).toDouble).toInt).r // TODO: Please build tree and retime appropriately

--- a/resources/synth/chisel-templates/templates/Controllers.scala
+++ b/resources/synth/chisel-templates/templates/Controllers.scala
@@ -206,10 +206,10 @@ class OuterControl(val sched: Sched, val depth: Int, val isFSM: Boolean = false,
     val stateFSM = Module(new FF(stateWidth))
     val doneReg = Module(new SRFF())
 
-    stateFSM.io.xBarW(0).data := io.nextState.asUInt
-    stateFSM.io.xBarW(0).init := io.initState.asUInt
-    stateFSM.io.xBarW(0).en := io.enable & iterDone.last.io.output.data
-    stateFSM.io.xBarW(0).reset := reset.toBool | ~io.enable
+    stateFSM.io.xBarW(0).data.head := io.nextState.asUInt
+    stateFSM.io.xBarW(0).init.head := io.initState.asUInt
+    stateFSM.io.xBarW(0).en.head := io.enable & iterDone.last.io.output.data
+    stateFSM.io.xBarW(0).reset.head := reset.toBool | ~io.enable
     io.state := stateFSM.io.output.data(0).asSInt
 
     doneReg.io.input.set := io.doneCondition & io.enable & iterDone.last.io.output.data.D(1)
@@ -296,12 +296,12 @@ class InnerControl(val sched: Sched, val isFSM: Boolean = false, val isPassthrou
     // if (latency == 0) depulser := Mux(io.enable, ~depulser, depulser)
     // else depulser := true.B
 
-    stateFSM.io.xBarW(0).data := io.nextState.asUInt
-    stateFSM.io.xBarW(0).init := io.initState.asUInt
-    stateFSM.io.xBarW(0).en := io.enable & io.ctrDone
+    stateFSM.io.xBarW(0).data.head := io.nextState.asUInt
+    stateFSM.io.xBarW(0).init.head := io.initState.asUInt
+    stateFSM.io.xBarW(0).en.head := io.enable & io.ctrDone
     // if (latency == 0) stateFSM.io.xBarW(0).en := io.enable & ~depulser
     // else stateFSM.io.xBarW(0).en := io.enable
-    stateFSM.io.xBarW(0).reset := reset.toBool | ~io.enable
+    stateFSM.io.xBarW(0).reset.head := reset.toBool | ~io.enable
     io.state := stateFSM.io.output.data(0).asSInt
 
     // Screwiness with "switch" signals until we have better fsm test cases

--- a/resources/synth/chisel-templates/templates/Counter.scala
+++ b/resources/synth/chisel-templates/templates/Counter.scala
@@ -170,16 +170,16 @@ class CompactingCounter(val lanes: Int, val depth: Int, val width: Int) extends 
   })
 
   val base = Module(new FF((width)))
-  base.io.xBarW(0).init := 0.U(width.W)
-  base.io.xBarW(0).reset := io.input.reset
-  base.io.xBarW(0).en := io.input.enables.reduce{_|_}
+  base.io.xBarW(0).init.head := 0.U(width.W)
+  base.io.xBarW(0).reset.head := io.input.reset
+  base.io.xBarW(0).en.head := io.input.enables.reduce{_|_}
 
   val count = base.io.output.data(0).asSInt
   val num_enabled = io.input.enables.map{e => Mux(e, 1.S(width.W), 0.S(width.W))}.reduce{_+_}
   val newval = count + Mux(io.input.dir, num_enabled, -num_enabled)
   val isMax = Mux(io.input.dir, newval >= depth.S, newval <= 0.S)
   val next = Mux(isMax, newval - depth.S(width.W), newval)
-  base.io.xBarW(0).data := Mux(io.input.reset, 0.asUInt, next.asUInt)
+  base.io.xBarW(0).data.head := Mux(io.input.reset, 0.asUInt, next.asUInt)
 
   io.output.count := base.io.output.data(0).asSInt
   io.output.done := io.input.enables.reduce{_|_} & isMax
@@ -243,9 +243,9 @@ class SingleCounter(val par: Int, val start: Option[Int], val stop: Option[Int],
         ,0) // Maybe delay by 1 cycle just in case this is a critical path.  Init should never change during execution
     }
     bases.zipWithIndex.foreach{ case (b,i) => 
-      b.io.xBarW(0).init := inits(i).asUInt
-      b.io.xBarW(0).reset := io.input.reset | {if (stride.isDefined) false.B else {Utils.getRetimed(io.input.stride,1) =/= io.input.stride}}
-      b.io.xBarW(0).en := io.input.enable
+      b.io.xBarW(0).init.head := inits(i).asUInt
+      b.io.xBarW(0).reset.head := io.input.reset | {if (stride.isDefined) false.B else {Utils.getRetimed(io.input.stride,1) =/= io.input.stride}}
+      b.io.xBarW(0).en.head := io.input.enable
     }
 
     val counts = bases.map(_.io.output.data(0).asSInt)
@@ -261,7 +261,7 @@ class SingleCounter(val par: Int, val start: Option[Int], val stop: Option[Int],
     val wasMax = RegNext(isMax, false.B)
     val wasEnabled = RegNext(io.input.enable, false.B)
     bases.zipWithIndex.foreach {case (b,i) => 
-      b.io.xBarW(0).data := Mux(io.input.reset, inits(i).asUInt, Mux(isMax, Mux(io.input.saturate, counts(i).asUInt, inits(i).asUInt), newvals(i).asUInt))
+      b.io.xBarW(0).data.head := Mux(io.input.reset, inits(i).asUInt, Mux(isMax, Mux(io.input.saturate, counts(i).asUInt, inits(i).asUInt), newvals(i).asUInt))
     }
 
     if(stride.isDefined) {
@@ -362,9 +362,9 @@ class SingleSCounter(val par: Int, val width: Int = 32) extends Module { // Sign
   if (par > 0) {
     val base = Module(new FF((width)))
     val init = io.input.start
-    base.io.xBarW(0).init := init.asUInt
-    base.io.xBarW(0).reset := io.input.reset
-    base.io.xBarW(0).en := io.input.reset | io.input.enable
+    base.io.xBarW(0).init.head := init.asUInt
+    base.io.xBarW(0).reset.head := io.input.reset
+    base.io.xBarW(0).en.head := io.input.reset | io.input.enable
 
     val count = base.io.output.data(0).asSInt
     val newval = count + (io.input.stride * par.S((width).W)) + io.input.gap // TODO: If I use *-* here, BigIPSim doesn't see par.S as a constant (but it sees par.U as one... -_-)
@@ -374,7 +374,7 @@ class SingleSCounter(val par: Int, val width: Int = 32) extends Module { // Sign
     val wasMin = RegNext(isMin, false.B)
     val wasEnabled = RegNext(io.input.enable, false.B)
     val next = Mux(isMax, Mux(io.input.saturate, count, init), Mux(isMin, io.input.stop + io.input.stride, newval))
-    base.io.xBarW(0).data := Mux(io.input.reset, init.asUInt, next.asUInt)
+    base.io.xBarW(0).data.head := Mux(io.input.reset, init.asUInt, next.asUInt)
 
     (0 until par).foreach { i => io.output.count(i) := count + i.S((width).W)*io.input.stride } // TODO: If I use *-* here, BigIPSim doesn't see par.S as a constant (but it sees par.U as one... -_-)
     (0 until par).foreach { i => 
@@ -422,9 +422,9 @@ class SingleSCounterCheap(val par: Int, val start: Int, val stop: Int, val strid
   if (par > 0) {
     val base = Module(new FF((width)))
     val init = start.asSInt
-    base.io.xBarW(0).init := init.asUInt
-    base.io.xBarW(0).reset := io.input.reset
-    base.io.xBarW(0).en := io.input.enable
+    base.io.xBarW(0).init.head := init.asUInt
+    base.io.xBarW(0).reset.head := io.input.reset
+    base.io.xBarW(0).en.head := io.input.enable
 
     val count = base.io.output.data(0).asSInt
     val newval_up = count + ((strideUp * par + gap).S((width).W))
@@ -436,7 +436,7 @@ class SingleSCounterCheap(val par: Int, val start: Int, val stop: Int, val strid
     val wasEnabled = RegNext(io.input.enable, false.B)
     // TODO: stop + strideDown in line below.. correct?
     val next = Mux(isMax & io.input.dir, Mux(io.input.saturate, count, init), Mux(isMin & ~io.input.dir & ~io.input.reset , (stop + strideDown).asSInt, Mux(io.input.dir, newval_up, newval_down)))
-    base.io.xBarW(0).data := Mux(io.input.reset, init.asUInt, next.asUInt)
+    base.io.xBarW(0).data.head := Mux(io.input.reset, init.asUInt, next.asUInt)
 
     (0 until par).foreach { i => io.output.count(i) := Mux(io.input.dir, count + (i*strideUp).S((width).W), count + (i*strideDown).S((width).W)) }
     (0 until par).foreach { i => 

--- a/resources/synth/chisel-templates/templates/MemPrimitives.scala
+++ b/resources/synth/chisel-templates/templates/MemPrimitives.scala
@@ -310,7 +310,7 @@ class SRAM(p: MemParams) extends MemPrimitive(p) {
     // Figure out which read port was active in direct
     val directIds = p.directRMux.sortByMuxPortAndCombine.collect{case(muxAddr,entry) if (i < entry._1.length) => p.directRMux.accessParsBelowMuxPort(muxAddr._1,0).sum + i }
     val directCandidatesEns = directIds.map(io.directR.map(_.en).flatten.toList(_))
-    val directCandidatesBanks = directIds.map(io.xBarR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
+    val directCandidatesBanks = directIds.map(io.directR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
     val directCandidatesOffsets = directIds.map(io.directR.map(_.ofs).flatten.toList(_))
     // Create bit vector to select which bank was activated by this io
     val sel = m.map{ mem => 

--- a/resources/synth/chisel-templates/templates/MemPrimitives.scala
+++ b/resources/synth/chisel-templates/templates/MemPrimitives.scala
@@ -48,13 +48,17 @@ case class MemParams(
   def hasXBarR: Boolean = xBarRMux.accessPars.sum > 0
   def numXBarW: Int = xBarWMux.accessPars.sum
   def numXBarR: Int = xBarRMux.accessPars.sum
+  def numXBarWPorts: Int = xBarWMux.accessPars.size
+  def numXBarRPorts: Int = xBarRMux.accessPars.size
   def hasDirectW: Boolean = directWMux.accessPars.sum > 0
   def hasDirectR: Boolean = directRMux.accessPars.sum > 0
   def numDirectW: Int = directWMux.accessPars.sum
   def numDirectR: Int = directRMux.accessPars.sum
+  def numDirectWPorts: Int = directWMux.accessPars.size
+  def numDirectRPorts: Int = directRMux.accessPars.size
   def totalOutputs: Int = {if (xBarRMux.toList.length > 0) xBarRMux.sortByMuxPortAndCombine.accessPars.max else 0} + {if (directRMux.toList.length > 0) directRMux.sortByMuxPortAndCombine.accessPars.max else 0}
   def numBanks: Int = banks.product
-  def defaultDirect: List[Int] = List.fill(banks.length)(99) // Dummy bank address when ~hasDirectR
+  def defaultDirect: List[List[Int]] = List(List.fill(banks.length)(99)) // Dummy bank address when ~hasDirectR
   def ofsWidth: Int = Utils.log2Up(depth/banks.product)
   def banksWidths: List[Int] = banks.map(Utils.log2Up(_))
   def elsWidth: Int = Utils.log2Up(depth) + 2
@@ -65,48 +69,52 @@ case class MemParams(
 }
 
 
-class R_XBar(val ofs_width:Int, val bank_width:List[Int]) extends Bundle {
-  val banks = HVec.tabulate(bank_width.length){i => UInt(bank_width(i).W)}
-  val ofs = UInt(ofs_width.W)
-  val en = Bool()
+class R_XBar(val port_width: Int, val ofs_width:Int, val bank_width:List[Int]) extends Bundle {
+  val banks = HVec.tabulate(port_width*bank_width.length){i => UInt(bank_width(i%bank_width.length).W)}
+  val ofs = Vec(port_width, UInt(ofs_width.W))
+  val en = Vec(port_width, Bool())
 
-  override def cloneType = (new R_XBar(ofs_width, bank_width)).asInstanceOf[this.type] // See chisel3 bug 358
+  override def cloneType = (new R_XBar(port_width, ofs_width, bank_width)).asInstanceOf[this.type] // See chisel3 bug 358
 }
 
-class W_XBar(val ofs_width:Int, val bank_width:List[Int], val data_width:Int) extends Bundle {
-  val banks = HVec.tabulate(bank_width.length){i => UInt(bank_width(i).W)}
-  val ofs = UInt(ofs_width.W)
-  val data = UInt(data_width.W)
-  val reset = Bool() // For FF
-  val init = UInt(data_width.W) // For FF
-  val shiftEn = Bool() // For ShiftRegFile
-  val en = Bool()
+class W_XBar(val port_width: Int, val ofs_width:Int, val bank_width:List[Int], val data_width:Int) extends Bundle {
+  val banks = HVec.tabulate(port_width*bank_width.length){i => UInt(bank_width(i%bank_width.length).W)}
+  val ofs = Vec(port_width, UInt(ofs_width.W))
+  val data = Vec(port_width, UInt(data_width.W))
+  val reset = Vec(port_width, Bool()) // For FF
+  val init = Vec(port_width, UInt(data_width.W)) // For FF
+  val shiftEn = Vec(port_width, Bool()) // For ShiftRegFile
+  val en = Vec(port_width, Bool())
 
-  override def cloneType = (new W_XBar(ofs_width, bank_width, data_width)).asInstanceOf[this.type] // See chisel3 bug 358
+  override def cloneType = (new W_XBar(port_width, ofs_width, bank_width, data_width)).asInstanceOf[this.type] // See chisel3 bug 358
 }
 
-class R_Direct(val ofs_width:Int, val banks:List[Int]) extends Bundle {
-  val ofs = UInt(ofs_width.W)
-  val en = Bool()
+class R_Direct(val port_width:Int, val ofs_width:Int, val banks:List[List[Int]]) extends Bundle {
+  val ofs = Vec(port_width, UInt(ofs_width.W))
+  val en = Vec(port_width, Bool())
 
-  override def cloneType = (new R_Direct(ofs_width, banks)).asInstanceOf[this.type] // See chisel3 bug 358
+  override def cloneType = (new R_Direct(port_width, ofs_width, banks)).asInstanceOf[this.type] // See chisel3 bug 358
 }
 
-class W_Direct(val ofs_width:Int, val banks:List[Int], val data_width:Int) extends Bundle {
-  val ofs = UInt(ofs_width.W)
-  val data = UInt(data_width.W)
-  val shiftEn = Bool() // For ShiftRegFile
-  val en = Bool()
+class W_Direct(val port_width: Int, val ofs_width:Int, val banks:List[List[Int]], val data_width:Int) extends Bundle {
+  val ofs = Vec(port_width, UInt(ofs_width.W))
+  val data = Vec(port_width, UInt(data_width.W))
+  val shiftEn = Vec(port_width, Bool()) // For ShiftRegFile
+  val en = Vec(port_width, Bool())
 
-  override def cloneType = (new W_Direct(ofs_width, banks, data_width)).asInstanceOf[this.type] // See chisel3 bug 358
+  override def cloneType = (new W_Direct(port_width, ofs_width, banks, data_width)).asInstanceOf[this.type] // See chisel3 bug 358
 }
 
 abstract class MemInterface(p: MemParams) extends Bundle {
-  var xBarW = Vec(1 max p.numXBarW, Input(new W_XBar(p.ofsWidth, p.banksWidths, p.bitWidth)))
-  var xBarR = Vec(1 max p.numXBarR, Input(new R_XBar(p.ofsWidth, p.banksWidths))) 
-  var directW = HVec(Array.tabulate(1 max p.numDirectW){i => Input(new W_Direct(p.ofsWidth, if (p.hasDirectW) p.directWMux.sortByMuxPortAndOfs.values.map(_._1).flatten.toList(i) else p.defaultDirect, p.bitWidth))})
-  var directR = HVec(Array.tabulate(1 max p.numDirectR){i => Input(new R_Direct(p.ofsWidth, if (p.hasDirectR) p.directRMux.sortByMuxPortAndOfs.values.map(_._1).flatten.toList(i) else p.defaultDirect))})
-  var flow = Vec(1 max (p.numXBarR + p.numDirectR), Input(Bool()))
+  var xBarW = HVec(Array.tabulate(1 max p.numXBarWPorts){i => Input(new W_XBar(p.xBarWMux.accessPars.getOr1(i), p.ofsWidth, p.banksWidths, p.bitWidth))})
+  var xBarR = HVec(Array.tabulate(1 max p.numXBarRPorts){i => Input(new R_XBar(p.xBarRMux.accessPars.getOr1(i), p.ofsWidth, p.banksWidths))}) 
+  var directW = HVec(Array.tabulate(1 max p.numDirectWPorts){i => 
+    Input(new W_Direct(p.directWMux.accessPars.getOr1(i), p.ofsWidth, if (p.hasDirectW) p.directWMux.sortByMuxPortAndOfs.values.map(_._1).flatten.flatten.toList.grouped(p.banks.length).toList else p.defaultDirect, p.bitWidth))
+  })
+  var directR = HVec(Array.tabulate(1 max p.numDirectRPorts){i => 
+    Input(new R_Direct(p.directRMux.accessPars.getOr1(i), p.ofsWidth, if (p.hasDirectR) p.directRMux.sortByMuxPortAndOfs.values.map(_._1).flatten.flatten.toList.grouped(p.banks.length).toList else p.defaultDirect))
+  })
+  var flow = Vec(1 max (p.numXBarRPorts + p.numDirectRPorts), Input(Bool()))
   var output = new Bundle {
     var data  = Vec(1 max p.totalOutputs, Output(UInt(p.bitWidth.W)))
   }
@@ -133,53 +141,54 @@ abstract class MemPrimitive(val p: MemParams) extends Module {
     case FIFOInterface => IO(new FIFOInterface(p))
   } 
 
-  var usedMuxPorts = List[(String,(Int,Int,Int))]() // Check if the muxPort, muxAddr, vecId is taken for this connection style (xBar or direct)
-  def connectXBarWPort(wBundle: W_XBar, bufferPort: Int, muxAddr: (Int, Int), vecId: Int): Unit = {
+  var usedMuxPorts = List[(String,(Int,Int))]() // Check if the muxPort, muxAddr is taken for this connection style (xBar or direct)
+  def connectXBarWPort(wBundle: W_XBar, bufferPort: Int, muxAddr: (Int, Int)): Unit = {
     assert(p.hasXBarW)
     assert(p.xBarWMux.contains(muxAddr))
-    assert(!usedMuxPorts.contains(("XBarW", (muxAddr._1,muxAddr._2,vecId))), s"Attempted to connect to XBarW port ($muxAddr,$vecId) twice!")
-    usedMuxPorts ::= ("XBarW", (muxAddr._1,muxAddr._2, vecId))
-    val base = p.xBarWMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).sum + vecId
+    assert(!usedMuxPorts.contains(("XBarW", (muxAddr._1,muxAddr._2))), s"Attempted to connect to XBarW port $muxAddr twice!")
+    usedMuxPorts ::= ("XBarW", (muxAddr._1,muxAddr._2))
+    val base = p.xBarWMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).size
     io.xBarW(base) := wBundle
   }
 
-  def connectXBarRPort(rBundle: R_XBar, bufferPort: Int, muxAddr: (Int, Int), vecId: Int): UInt = {connectXBarRPort(rBundle, bufferPort, muxAddr, vecId, true.B)}
+  def connectXBarRPort(rBundle: R_XBar, bufferPort: Int, muxAddr: (Int, Int)): Seq[UInt] = {connectXBarRPort(rBundle, bufferPort, muxAddr, true.B)}
 
-  def connectXBarRPort(rBundle: R_XBar, bufferPort: Int, muxAddr: (Int, Int), vecId: Int, flow: Bool): UInt = {
+  def connectXBarRPort(rBundle: R_XBar, bufferPort: Int, muxAddr: (Int, Int), flow: Bool): Seq[UInt] = {
     assert(p.hasXBarR)
     assert(p.xBarRMux.contains(muxAddr))
-    assert(!usedMuxPorts.contains(("XBarR", (muxAddr._1,muxAddr._2,vecId))), s"Attempted to connect to XBarR port ($muxAddr,$vecId) twice!")
-    usedMuxPorts ::= ("XBarR", (muxAddr._1,muxAddr._2, vecId))
-    val base = p.xBarRMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).sum + vecId
+    assert(!usedMuxPorts.contains(("XBarR", (muxAddr._1,muxAddr._2))), s"Attempted to connect to XBarR port $muxAddr twice!")
+    usedMuxPorts ::= ("XBarR", (muxAddr._1,muxAddr._2))
+    val base = p.xBarRMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).size
     io.xBarR(base) := rBundle    
     io.flow(base) := flow
     // Temp fix for merged readers not recomputing port info
     val outBase = p.xBarRMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).sum - p.xBarRMux.accessParsBelowMuxPort(muxAddr._1,0).sum
-    io.output.data(outBase + vecId)
+    rBundle.port_width.indices[UInt]{vecId => io.output.data(outBase + vecId)}
+    
   }
 
-  def connectDirectWPort(wBundle: W_Direct, bufferPort: Int, muxAddr: (Int, Int), vecId: Int): Unit = {
+  def connectDirectWPort(wBundle: W_Direct, bufferPort: Int, muxAddr: (Int, Int)): Unit = {
     assert(p.hasDirectW)
     assert(p.directWMux.contains(muxAddr))
-    assert(!usedMuxPorts.contains(("DirectW", (muxAddr._1,muxAddr._2,vecId))), s"Attempted to connect to DirectW port ($muxAddr,$vecId) twice!")
-    usedMuxPorts ::= ("DirectW", (muxAddr._1,muxAddr._2, vecId))
-    val base = p.directWMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).sum + vecId
+    assert(!usedMuxPorts.contains(("DirectW", (muxAddr._1,muxAddr._2))), s"Attempted to connect to DirectW port $muxAddr twice!")
+    usedMuxPorts ::= ("DirectW", (muxAddr._1,muxAddr._2))
+    val base = p.directWMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).size
     io.directW(base) := wBundle
   }
 
-  def connectDirectRPort(rBundle: R_Direct, bufferPort: Int, muxAddr: (Int, Int), vecId: Int): UInt = {connectDirectRPort(rBundle, bufferPort, muxAddr, vecId, true.B)}
+  def connectDirectRPort(rBundle: R_Direct, bufferPort: Int, muxAddr: (Int, Int)): Seq[UInt] = {connectDirectRPort(rBundle, bufferPort, muxAddr, true.B)}
 
-  def connectDirectRPort(rBundle: R_Direct, bufferPort: Int, muxAddr: (Int, Int), vecId: Int, flow: Bool): UInt = {
+  def connectDirectRPort(rBundle: R_Direct, bufferPort: Int, muxAddr: (Int, Int), flow: Bool): Seq[UInt] = {
     assert(p.hasDirectR)
     assert(p.directRMux.contains(muxAddr))
-    assert(!usedMuxPorts.contains(("DirectR", (muxAddr._1,muxAddr._2,vecId))), s"Attempted to connect to DirectR port ($muxAddr,$vecId) twice!")
-    usedMuxPorts ::= ("DirectR", (muxAddr._1,muxAddr._2, vecId))
-    val base = p.directRMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).sum + vecId
+    assert(!usedMuxPorts.contains(("DirectR", (muxAddr._1,muxAddr._2))), s"Attempted to connect to DirectR port $muxAddr twice!")
+    usedMuxPorts ::= ("DirectR", (muxAddr._1,muxAddr._2))
+    val base = p.directRMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).size
     io.directR(base) := rBundle    
     io.flow(base + p.numXBarR) := flow
     // Temp fix for merged readers not recomputing port info
     val outBase = p.directRMux.accessParsBelowMuxPort(muxAddr._1,muxAddr._2).sum - p.directRMux.accessParsBelowMuxPort(muxAddr._1,0).sum
-    io.output.data(outBase + vecId)
+    rBundle.port_width.indices[UInt]{vecId => io.output.data(outBase + vecId)}
   }
 
 }
@@ -215,65 +224,76 @@ class SRAM(p: MemParams) extends MemPrimitive(p) {
   // Handle Writes
   m.foreach{ mem => 
     // Check all xBar w ports against this bank's coords
-    val xBarSelect = io.xBarW.map(_.banks).zip(io.xBarW.map(_.en)).map{ case(bids, en) => 
+    val xBarSelect = io.xBarW.map(_.banks).flatten.grouped(p.banks.length).toList.zip(io.xBarW.map(_.en).flatten).map{ case(bids, en) => 
       bids.zip(mem._2).map{case (b,coord) => b === coord.U}.reduce{_&&_} & {if (p.hasXBarW) en else false.B}
     }
     // Check all direct W ports against this bank's coords
-    val directSelect = io.directW.filter(_.banks.zip(mem._2).map{case (b,coord) => b == coord}.reduce(_&_))
+    val directSelectEns = io.directW.map(_.en).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(mem._2).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
+    val directSelectDatas = io.directW.map(_.data).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(mem._2).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
+    val directSelectOffsets = io.directW.map(_.ofs).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(mem._2).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
 
     // Unmask write port if any of the above match
-    mem._1.io.wMask := xBarSelect.reduce{_|_} | {if (directSelect.nonEmpty) directSelect.map(_.en).reduce(_|_) else false.B}
+    mem._1.io.wMask := xBarSelect.reduce{_|_} | {directSelectEns.or}
 
     // Connect matching W port to memory
-    if (directSelect.length > 0 & p.hasXBarW) {           // Has direct and x
-      val directChoice = chisel3.util.PriorityMux(directSelect.map(_.en), directSelect)
-      val xBarChoice = chisel3.util.PriorityMux(xBarSelect, io.xBarW)
-      mem._1.io.w.ofs  := Mux(directSelect.map(_.en).reduce(_|_), directChoice.ofs, xBarChoice.ofs)
-      mem._1.io.w.data := Mux(directSelect.map(_.en).reduce(_|_), directChoice.data, xBarChoice.data)
-      mem._1.io.w.en   := Mux(directSelect.map(_.en).reduce(_|_), directChoice.en, xBarChoice.en)
-    } else if (p.hasXBarW && directSelect.length == 0) {  // Has x only
-      val xBarChoice = chisel3.util.PriorityMux(xBarSelect, io.xBarW)
-      mem._1.io.w.ofs  := xBarChoice.ofs
-      mem._1.io.w.data := xBarChoice.data
-      mem._1.io.w.en   := xBarChoice.en 
-    } else if (directSelect.length > 0) {               // Has direct only
-      val directChoice = chisel3.util.PriorityMux(directSelect.map(_.en), directSelect)
-      mem._1.io.w.ofs  := directChoice.ofs
-      mem._1.io.w.data := directChoice.data
-      mem._1.io.w.en   := directChoice.en 
+    if (directSelectEns.length > 0 & p.hasXBarW) {           // Has direct and x
+      val directChoiceEn = chisel3.util.PriorityMux(directSelectEns, directSelectEns)
+      val directChoiceData = chisel3.util.PriorityMux(directSelectEns, directSelectDatas)
+      val directChoiceOffset = chisel3.util.PriorityMux(directSelectEns, directSelectOffsets)
+      val xBarChoiceEn = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.en).flatten.toList)
+      val xBarChoiceData = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.data).flatten.toList)
+      val xBarChoiceOffset = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.ofs).flatten.toList)
+      mem._1.io.w.ofs.head  := Mux(directSelectEns.or, directChoiceOffset, xBarChoiceOffset)
+      mem._1.io.w.data.head := Mux(directSelectEns.or, directChoiceData, xBarChoiceData)
+      mem._1.io.w.en.head   := Mux(directSelectEns.or, directChoiceEn, xBarChoiceEn)
+    } else if (p.hasXBarW && directSelectEns.length == 0) {  // Has x only
+      val xBarChoiceEn = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.en).flatten.toList)
+      val xBarChoiceData = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.data).flatten.toList)
+      val xBarChoiceOffset = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.ofs).flatten.toList)
+      mem._1.io.w.ofs.head  := xBarChoiceOffset
+      mem._1.io.w.data.head := xBarChoiceData
+      mem._1.io.w.en.head   := xBarChoiceEn 
+    } else if (directSelectEns.length > 0) {               // Has direct only
+      val directChoiceEn = chisel3.util.PriorityMux(directSelectEns, directSelectEns)
+      val directChoiceData = chisel3.util.PriorityMux(directSelectEns, directSelectDatas)
+      val directChoiceOffset = chisel3.util.PriorityMux(directSelectEns, directSelectOffsets)
+      mem._1.io.w.ofs.head  := directChoiceOffset
+      mem._1.io.w.data.head := directChoiceData
+      mem._1.io.w.en.head   := directChoiceEn
     }
   }
 
   // Handle Reads
   m.foreach{ mem => 
     // Check all xBar r ports against this bank's coords
-    val xBarSelect = io.xBarR.map(_.banks).zip(io.xBarR.map(_.en)).map{ case(bids, en) => 
-      bids.zip(mem._2).map{case (b,coord) => b === coord.U}.reduce{_&&_} & en 
+    val xBarSelect = io.xBarR.map(_.banks).flatten.grouped(p.banks.length).toList.zip(io.xBarR.map(_.en).flatten).map{ case(bids, en) => 
+      bids.zip(mem._2).map{case (b,coord) => b === coord.U}.reduce{_&&_} & {if (p.hasXBarW) en else false.B}
     }
     // Check all direct r ports against this bank's coords
-    val directSelect = io.directR.filter(_.banks.zip(mem._2).map{case (b,coord) => b == coord}.reduce(_&_))
+    val directSelectEns = io.directR.map(_.en).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(mem._2).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
+    val directSelectOffsets = io.directR.map(_.ofs).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(mem._2).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
 
     // Unmask write port if any of the above match
-    mem._1.io.rMask := {if (p.hasXBarR) xBarSelect.reduce{_|_} else true.B} & {if (directSelect.length > 0) directSelect.map(_.en).reduce(_|_) else true.B}
+    mem._1.io.rMask := {if (p.hasXBarR) xBarSelect.reduce{_|_} else true.B} & directSelectEns.or
     // Connect matching R port to memory
-    if (directSelect.length > 0 & p.hasXBarR) {          // Has direct and x
-      mem._1.io.r.ofs  := Mux(directSelect.map(_.en).reduce(_|_), chisel3.util.PriorityMux(directSelect.map(_.en), directSelect).ofs, chisel3.util.PriorityMux(xBarSelect, io.xBarR).ofs)
-      mem._1.io.r.en   := Mux(directSelect.map(_.en).reduce(_|_), chisel3.util.PriorityMux(directSelect.map(_.en), directSelect).en, chisel3.util.PriorityMux(xBarSelect, io.xBarR).en)
-    } else if (p.hasXBarR && directSelect.length == 0) { // Has x only
-      mem._1.io.r.ofs  := chisel3.util.PriorityMux(xBarSelect, io.xBarR).ofs
-      mem._1.io.r.en   := chisel3.util.PriorityMux(xBarSelect, io.xBarR).en 
-    } else if (directSelect.length > 0) {                                           // Has direct only
-      mem._1.io.r.ofs  := chisel3.util.PriorityMux(directSelect.map(_.en), directSelect).ofs
-      mem._1.io.r.en   := chisel3.util.PriorityMux(directSelect.map(_.en), directSelect).en 
+    if (directSelectEns.length > 0 & p.hasXBarR) {          // Has direct and x
+      mem._1.io.r.ofs.head  := Mux(directSelectEns.or, chisel3.util.PriorityMux(directSelectEns, directSelectOffsets), chisel3.util.PriorityMux(xBarSelect, io.xBarR.map(_.ofs).flatten))
+      mem._1.io.r.en.head   := Mux(directSelectEns.or, chisel3.util.PriorityMux(directSelectEns, directSelectEns), chisel3.util.PriorityMux(xBarSelect, io.xBarR.map(_.en).flatten))
+    } else if (p.hasXBarR && directSelectEns.length == 0) { // Has x only
+      mem._1.io.r.ofs.head  := chisel3.util.PriorityMux(xBarSelect, io.xBarR.map(_.ofs).flatten)
+      mem._1.io.r.en.head   := chisel3.util.PriorityMux(xBarSelect, io.xBarR.map(_.ofs).flatten)
+    } else if (directSelectEns.length > 0) {                                           // Has direct only
+      mem._1.io.r.ofs.head  := chisel3.util.PriorityMux(directSelectEns, directSelectOffsets)
+      mem._1.io.r.en.head   := chisel3.util.PriorityMux(directSelectEns, directSelectEns) 
     }
     // Use flow for last active r port
-    val sels = Array.tabulate(directSelect.size + xBarSelect.size){i => 
+    val sels = Array.tabulate(directSelectEns.size + xBarSelect.size){i => 
       val r = Module(new SRFF())
-      if (i < directSelect.size) r.io.input.set := directSelect(i).en 
-      else r.io.input.set := xBarSelect(i - directSelect.size)
+      if (i < directSelectEns.size) r.io.input.set := directSelectEns(i)
+      else r.io.input.set := xBarSelect(i - directSelectEns.size)
       r.io.input.reset := false.B
-      if (i < directSelect.size) r.io.input.asyn_reset :=  (directSelect.patch(i,Nil,1).map(_.en) ++ xBarSelect).foldLeft(false.B)(_|_) 
-      else r.io.input.asyn_reset := (directSelect.map(_.en) ++ xBarSelect.patch(i-directSelect.size, Nil, 1)).foldLeft(false.B)(_|_)
+      if (i < directSelectEns.size) r.io.input.asyn_reset :=  (directSelectEns.patch(i,Nil,1) ++ xBarSelect).foldLeft(false.B)(_|_) 
+      else r.io.input.asyn_reset := (directSelectEns ++ xBarSelect.patch(i-directSelectEns.size, Nil, 1)).foldLeft(false.B)(_|_)
       r.io.output.data
     }
     mem._1.io.flow   := chisel3.util.PriorityMux(sels, io.flow)
@@ -283,17 +303,22 @@ class SRAM(p: MemParams) extends MemPrimitive(p) {
   io.output.data.zipWithIndex.foreach { case (wire,i) => 
     // Figure out which read port was active in xBar
     val xBarIds = p.xBarRMux.sortByMuxPortAndCombine.collect{case(muxAddr,entry) if (i < entry._1) => p.xBarRMux.accessParsBelowMuxPort(muxAddr._1,0).sum + i }
-    val xBarCandidates = xBarIds.map(io.xBarR(_))
+    val xBarCandidatesEns = xBarIds.map(io.xBarR.map(_.en).flatten.toList(_))
+    val xBarCandidatesBanks = xBarIds.map(io.xBarR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
+    val xBarCandidatesOffsets = xBarIds.map(io.xBarR.map(_.ofs).flatten.toList(_))
+
     // Figure out which read port was active in direct
     val directIds = p.directRMux.sortByMuxPortAndCombine.collect{case(muxAddr,entry) if (i < entry._1.length) => p.directRMux.accessParsBelowMuxPort(muxAddr._1,0).sum + i }
-    val directCandidates = directIds.map(io.directR(_))
-    // Create bit vector to select which bank was activated by this i
+    val directCandidatesEns = directIds.map(io.directR.map(_.en).flatten.toList(_))
+    val directCandidatesBanks = directIds.map(io.xBarR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
+    val directCandidatesOffsets = directIds.map(io.directR.map(_.ofs).flatten.toList(_))
+    // Create bit vector to select which bank was activated by this io
     val sel = m.map{ mem => 
-      val xBarWants = if (xBarCandidates.toList.length > 0) xBarCandidates.map {x => 
-        x.banks.zip(mem._2).map{case (b, coord) => Utils.getRetimed(b, Utils.sramload_latency) === coord.U}.reduce{_&&_} && Utils.getRetimed(x.en, Utils.sramload_latency)
+      val xBarWants = if (xBarCandidatesEns.toList.length > 0) (xBarCandidatesEns, xBarCandidatesBanks, xBarCandidatesOffsets).zipped.map {case(en,banks,ofs) => 
+        banks.zip(mem._2).map{case (b, coord) => Utils.getRetimed(b, Utils.sramload_latency) === coord.U}.reduce{_&&_} && Utils.getRetimed(en, Utils.sramload_latency)
       }.reduce{_||_} else false.B
-      val directWants = if (directCandidates.toList.length > 0) directCandidates.map {x => 
-        x.banks.zip(mem._2).map{case (b, coord) => b == coord}.reduce{_&&_}.B && Utils.getRetimed(x.en, Utils.sramload_latency)
+      val directWants = if (directCandidatesEns.toList.length > 0) (directCandidatesEns, directCandidatesBanks, directCandidatesOffsets).zipped.map {case(en,banks,ofs) => 
+        banks.zip(mem._2).map{case (b, coord) => b == coord}.reduce{_&&_}.B && Utils.getRetimed(en, Utils.sramload_latency)
       }.reduce{_||_} else false.B
       xBarWants || directWants
     }
@@ -322,11 +347,11 @@ class FF(p: MemParams) extends MemPrimitive(p) {
   def this(bitWidth: Int) = this(List(1), bitWidth,List(1), List(1), XMap((0,0) -> (1, None)), XMap((0,0) -> (1, None)), DMap(), DMap(), BankedMemory, None, false, 0)
   def this(bitWidth: Int, xBarWMux: XMap, xBarRMux: XMap, inits: Option[List[Double]], fracBits: Int) = this(List(1), bitWidth,List(1), List(1), xBarWMux, xBarRMux, DMap(), DMap(), BankedMemory, inits, false, fracBits)
 
-  val ff = if (p.inits.isDefined) RegInit((p.inits.get.head*scala.math.pow(2,p.fracBits)).toLong.S(p.bitWidth.W).asUInt) else RegInit(io.xBarW(0).init)
-  val anyReset = io.xBarW.map{_.reset}.reduce{_|_}
-  val anyEnable = io.xBarW.map{_.en}.reduce{_|_}
-  val wr_data = chisel3.util.Mux1H(io.xBarW.map{_.en}, io.xBarW.map{_.data})
-  ff := Mux(anyReset, io.xBarW(0).init, Mux(anyEnable, wr_data, ff))
+  val ff = if (p.inits.isDefined) RegInit((p.inits.get.head*scala.math.pow(2,p.fracBits)).toLong.S(p.bitWidth.W).asUInt) else RegInit(io.xBarW(0).init.head)
+  val anyReset: Bool = io.xBarW.map{_.reset}.flatten.toList.reduce{_|_}
+  val anyEnable: Bool = io.xBarW.map{_.en}.flatten.toList.reduce{_|_}
+  val wr_data: UInt = chisel3.util.Mux1H(io.xBarW.map{_.en}.flatten.toList, io.xBarW.map{_.data}.flatten.toList)
+  ff := Mux(anyReset, io.xBarW(0).init.head, Mux(anyEnable, wr_data, ff))
   io.output.data.foreach(_ := ff)
 
 }
@@ -424,8 +449,8 @@ class LIFO(p: MemParams) extends MemPrimitive(p) {
 
   // Register for tracking number of elements in FILO
   val elements = Module(new IncDincCtr(pW,pR, p.depth))
-  elements.io.input.inc_en := io.xBarW.map(_.en).reduce{_|_}
-  elements.io.input.dinc_en := io.xBarR.map(_.en).reduce{_|_}
+  elements.io.input.inc_en := io.xBarW.map(_.en).flatten.toList.reduce{_|_}
+  elements.io.input.dinc_en := io.xBarR.map(_.en).flatten.toList.reduce{_|_}
 
   // Create physical mems
   val m = (0 until par).map{ i => Module(new Mem1D(p.depth/par, p.bitWidth))}
@@ -433,8 +458,8 @@ class LIFO(p: MemParams) extends MemPrimitive(p) {
   // Create head and reader sub counters
   val sa_width = 2 + Utils.log2Up(par)
   val subAccessor = Module(new SingleSCounterCheap(1,0,par,pW,-pR,0,sa_width))
-  subAccessor.io.input.enable := io.xBarW.map(_.en).reduce{_|_} | io.xBarR.map(_.en).reduce{_|_}
-  subAccessor.io.input.dir := io.xBarW.map(_.en).reduce{_|_}
+  subAccessor.io.input.enable := io.xBarW.map(_.en).flatten.toList.reduce{_|_} | io.xBarR.map(_.en).flatten.toList.reduce{_|_}
+  subAccessor.io.input.dir := io.xBarW.map(_.en).flatten.toList.reduce{_|_}
   subAccessor.io.input.reset := reset
   subAccessor.io.input.saturate := false.B
   val subAccessor_prev = Mux(subAccessor.io.output.count(0) - pR.S(sa_width.W) < 0.S(sa_width.W), (par-pR).S(sa_width.W), subAccessor.io.output.count(0) - pR.S(sa_width.W))
@@ -442,8 +467,8 @@ class LIFO(p: MemParams) extends MemPrimitive(p) {
   // Create head and reader counters
   val a_width = 2 + Utils.log2Up(p.depth/par)
   val accessor = Module(new SingleSCounterCheap(1, 0, (p.depth/par), 1, -1, 0, a_width))
-  accessor.io.input.enable := (io.xBarW.map(_.en).reduce{_|_} & subAccessor.io.output.done) | (io.xBarR.map(_.en).reduce{_|_} & subAccessor_prev === 0.S(sa_width.W))
-  accessor.io.input.dir := io.xBarW.map(_.en).reduce{_|_}
+  accessor.io.input.enable := (io.xBarW.map(_.en).flatten.toList.reduce{_|_} & subAccessor.io.output.done) | (io.xBarR.map(_.en).flatten.toList.reduce{_|_} & subAccessor_prev === 0.S(sa_width.W))
+  accessor.io.input.dir := io.xBarW.map(_.en).flatten.toList.reduce{_|_}
   accessor.io.input.reset := reset
   accessor.io.input.saturate := false.B
 
@@ -456,9 +481,9 @@ class LIFO(p: MemParams) extends MemPrimitive(p) {
       val xBarCandidates = xBarIds.map{case n => io.xBarW(n+i)}
       // Make connections to memory
       mem.io.w.ofs := accessor.io.output.count(0).asUInt
-      mem.io.w.data := Mux1H(xBarCandidates.map(_.en), xBarCandidates.map(_.data))
-      mem.io.w.en := xBarCandidates.map(_.en).reduce{_|_}
-      mem.io.wMask := xBarCandidates.map(_.en).reduce{_|_}
+      mem.io.w.data := Mux1H(xBarCandidates.map(_.en).flatten.toList, xBarCandidates.map(_.data).flatten.toList)
+      mem.io.w.en := xBarCandidates.map(_.en).flatten.toList.reduce{_|_}
+      mem.io.wMask := xBarCandidates.map(_.en).flatten.toList.reduce{_|_}
     }
   } else {
     (0 until pW).foreach { w_i => 
@@ -468,9 +493,9 @@ class LIFO(p: MemParams) extends MemPrimitive(p) {
         val xBarCandidates = xBarIds.map{case n => io.xBarW(n+(i*pW+w_i))}
         // Make connections to memory
         m(w_i + i*-*pW).io.w.ofs := accessor.io.output.count(0).asUInt
-        m(w_i + i*-*pW).io.w.data := Mux1H(xBarCandidates.map(_.en), xBarCandidates.map(_.data))
-        m(w_i + i*-*pW).io.w.en := xBarCandidates.map(_.en).reduce{_|_} & (subAccessor.io.output.count(0) === (i*pW).S(sa_width.W))
-        m(w_i + i*-*pW).io.wMask := xBarCandidates.map(_.en).reduce{_|_} & (subAccessor.io.output.count(0) === (i*pW).S(sa_width.W))
+        m(w_i + i*-*pW).io.w.data := Mux1H(xBarCandidates.map(_.en).flatten.toList, xBarCandidates.map(_.data).flatten.toList)
+        m(w_i + i*-*pW).io.w.en := xBarCandidates.map(_.en).flatten.toList.reduce{_|_} & (subAccessor.io.output.count(0) === (i*pW).S(sa_width.W))
+        m(w_i + i*-*pW).io.wMask := xBarCandidates.map(_.en).flatten.toList.reduce{_|_} & (subAccessor.io.output.count(0) === (i*pW).S(sa_width.W))
       }
     }
   }
@@ -479,8 +504,8 @@ class LIFO(p: MemParams) extends MemPrimitive(p) {
   if (pW == pR) {
     m.zipWithIndex.foreach { case (mem, i) => 
       mem.io.r.ofs := (accessor.io.output.count(0) - 1.S(a_width.W)).asUInt
-      mem.io.r.en := io.xBarR.map(_.en).reduce{_|_}
-      mem.io.rMask := io.xBarR.map(_.en).reduce{_|_}
+      mem.io.r.en := io.xBarR.map(_.en).flatten.toList.reduce{_|_}
+      mem.io.rMask := io.xBarR.map(_.en).flatten.toList.reduce{_|_}
       io.output.data(i) := mem.io.output.data
     }
   } else {
@@ -489,8 +514,8 @@ class LIFO(p: MemParams) extends MemPrimitive(p) {
       val rData = Wire(Vec( (par/pR), UInt(p.bitWidth.W)))
       (0 until (par /-/ pR)).foreach { i => 
         m(r_i + i*-*pR).io.r.ofs := (accessor.io.output.count(0) - 1.S(sa_width.W)).asUInt
-        m(r_i + i*-*pR).io.r.en := io.xBarR.map(_.en).reduce{_|_} & (subAccessor_prev === (i*-*pR).S(sa_width.W))
-        m(r_i + i*-*pR).io.rMask := io.xBarR.map(_.en).reduce{_|_} & (subAccessor_prev === (i*-*pR).S(sa_width.W))
+        m(r_i + i*-*pR).io.r.en := io.xBarR.map(_.en).flatten.toList.reduce{_|_} & (subAccessor_prev === (i*-*pR).S(sa_width.W))
+        m(r_i + i*-*pR).io.rMask := io.xBarR.map(_.en).flatten.toList.reduce{_|_} & (subAccessor_prev === (i*-*pR).S(sa_width.W))
         rSel(i) := subAccessor_prev === i.S
         rData(i) := m(r_i + i*pR).io.output.data
       }
@@ -539,47 +564,56 @@ class ShiftRegFile(p: MemParams) extends MemPrimitive(p) {
   // Handle Writes
   m.foreach{ case(mem, coords, flatCoord) => 
     // Check all xBar w ports against this bank's coords
-    val xBarSelect = (io.xBarW.map(_.banks), io.xBarW.map(_.en), io.xBarW.map(_.shiftEn)).zipped.map{ case(bids, en, shiftEn) => 
+    val xBarSelect = (io.xBarW.map(_.banks).flatten.toList.grouped(p.banks.length).toList, io.xBarW.map(_.en).flatten.toList, io.xBarW.map(_.shiftEn).flatten.toList).zipped.map{ case(bids, en, shiftEn) => 
       bids.zip(coords).map{case (b,coord) => b === coord.U}.reduce{_&&_} & {if (p.hasXBarW) en | shiftEn else false.B}
     }
     // Check all direct W ports against this bank's coords
-    val directSelect = io.directW.filter(_.banks.zip(coords).map{case (b,coord) => b == coord}.reduce(_&_))
+    val directSelectEns = io.directW.map(_.en).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(coords).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
+    val directSelectDatas = io.directW.map(_.data).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(coords).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
+    val directSelectOffsets = io.directW.map(_.ofs).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(coords).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
+    val directSelectShiftEns = io.directW.map(_.shiftEn).flatten.zip(io.directW.map(_.banks.flatten).flatten.grouped(p.banks.length).toList).collect{case (en, banks) if (banks.zip(coords).map{case (b,coord) => b == coord}.reduce(_&_)) => en}
 
     // Unmask write port if any of the above match
-    val wMask = xBarSelect.reduce{_|_} | {if (directSelect.nonEmpty) directSelect.map{x => x.en | x.shiftEn}.reduce(_|_) else false.B}
+    val wMask = xBarSelect.reduce{_|_} | directSelectEns.or | directSelectShiftEns.or
 
     // Check if shiftEn is turned on for this line, guaranteed false on entry plane
     val shiftMask = if (p.axis >= 0 && coords(p.axis) != 0) {
       // XBarW requests shift
-      val axisShiftXBar = io.xBarW.map(_.banks).zip(io.xBarW.map(_.shiftEn)).map{ case(bids, en) => 
+      val axisShiftXBar = io.xBarW.map(_.banks).flatten.toList.grouped(p.banks.length).toList.zip(io.xBarW.map(_.shiftEn).flatten.toList).map{ case(bids, en) => 
         bids.zip(coords).zipWithIndex.map{case ((b, coord),id) => if (id == p.axis) true.B else b === coord.U}.reduce{_&&_} & {if (p.hasXBarW) en else false.B}
       }
-      // DirectW requests shift
-      val axisShiftDirect = io.directW.filter{case x => stripCoord(x.banks, p.axis).zip(stripCoord(coords, p.axis)).map{case (b,coord) => b == coord}.reduce(_&_)}
+      // // DirectW requests shift
+      // val axisShiftDirect = io.directW.map(_.banks).flatten.filter{case banks => stripCoord(banks, p.axis).zip(stripCoord(coords, p.axis)).map{case (b,coord) => b == coord}.reduce(_&_)}
 
       // Unmask shift if any of the above match
-      axisShiftXBar.reduce{_|_} | {if (directSelect.nonEmpty) directSelect.map(_.shiftEn).reduce(_|_) else false.B}
+      axisShiftXBar.reduce{_|_} | directSelectShiftEns.or
     } else false.B
 
     // Connect matching W port to memory
     val shiftSource = if (p.axis >= 0 && coords(p.axis) != 0) m.filter{case (_,c,_) => decrementAxisCoord(coords,p.axis) == c}.head._1 else mem
     val shiftEnable = if (p.axis >= 0 && coords(p.axis) != 0) shiftMask else false.B
     val (data, enable) = 
-      if (directSelect.length > 0 & p.hasXBarW) {           // Has direct and x
-        val liveDirectWire = chisel3.util.PriorityMux(directSelect.map{x => x.en | x.shiftEn}, directSelect)
-        val liveXBarWire = chisel3.util.PriorityMux(xBarSelect, io.xBarW)
-        val enable = Mux(directSelect.map{x => x.en | x.shiftEn}.reduce(_|_), (liveDirectWire.en | liveDirectWire.shiftEn), (liveXBarWire.en | liveXBarWire.shiftEn)) & wMask
-        val data = Mux(directSelect.map{x => x.en | x.shiftEn}.reduce(_|_), liveDirectWire.data, liveXBarWire.data)
+      if (directSelectEns.length > 0 & p.hasXBarW) {           // Has direct and x
+        val liveDirectWireSelects = directSelectEns.zip(directSelectShiftEns).map{case (e,se) => e | se}
+        val liveDirectWireData = chisel3.util.PriorityMux(liveDirectWireSelects, directSelectDatas)
+        val liveDirectWireEn = chisel3.util.PriorityMux(liveDirectWireSelects, liveDirectWireSelects)
+        val liveXBarWireEn = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.en).flatten.zip(io.xBarW.map(_.shiftEn).flatten).map{case(e,se) => e | se})
+        val liveXBarWireData = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.data).flatten)
+        val enable = Mux(liveDirectWireSelects.or, liveDirectWireEn, liveXBarWireEn) & wMask
+        val data = Mux(liveDirectWireSelects.or, liveDirectWireData, liveXBarWireData)
         (data, enable)
-      } else if (p.hasXBarW && directSelect.length == 0) {  // Has x only
-        val liveXBarWire = chisel3.util.PriorityMux(xBarSelect, io.xBarW)
-        val enable = (liveXBarWire.en | liveXBarWire.shiftEn) & wMask
-        val data = liveXBarWire.data
+      } else if (p.hasXBarW && directSelectEns.length == 0) {  // Has x only
+        val liveXBarWireEn = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.en).flatten.zip(io.xBarW.map(_.shiftEn).flatten).map{case(e,se) => e | se})
+        val liveXBarWireData = chisel3.util.PriorityMux(xBarSelect, io.xBarW.map(_.data).flatten)
+        val enable = (liveXBarWireEn) & wMask
+        val data = liveXBarWireData
         (data, enable)
-      } else if (directSelect.length > 0) {                                            // Has direct only
-        val liveDirectWire = chisel3.util.PriorityMux(directSelect.map{x => x.en | x.shiftEn}, directSelect)
-        val enable = (liveDirectWire.en | liveDirectWire.shiftEn)& wMask
-        val data = liveDirectWire.data
+      } else if (directSelectEns.length > 0) {                                            // Has direct only
+        val liveDirectWireSelects = directSelectEns.zip(directSelectShiftEns).map{case (e,se) => e | se}
+        val liveDirectWireData = chisel3.util.PriorityMux(liveDirectWireSelects, directSelectDatas)
+        val liveDirectWireEn = chisel3.util.PriorityMux(liveDirectWireSelects, liveDirectWireSelects)
+        val enable = (liveDirectWireEn) & wMask
+        val data = liveDirectWireData
         (data, enable)
       } else (0.U, false.B)
     if (p.isBuf) mem := Mux(io.asInstanceOf[ShiftRegFileInterface].dump_en, io.asInstanceOf[ShiftRegFileInterface].dump_in(flatCoord), Mux(shiftEnable, shiftSource, Mux(enable, data, mem)))
@@ -590,17 +624,22 @@ class ShiftRegFile(p: MemParams) extends MemPrimitive(p) {
   io.output.data.zipWithIndex.foreach { case (wire,i) => 
     // Figure out which read port was active in xBar
     val xBarIds = p.xBarRMux.sortByMuxPortAndCombine.collect{case(muxAddr,entry) if (i < entry._1) => p.xBarRMux.accessParsBelowMuxPort(muxAddr._1,0).sum + i }
-    val xBarCandidates = xBarIds.map(io.xBarR(_))
+    val xBarCandidatesEns = xBarIds.map(io.xBarR.map(_.en).flatten.toList(_))
+    val xBarCandidatesBanks = xBarIds.map(io.xBarR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
+    val xBarCandidatesOffsets = xBarIds.map(io.xBarR.map(_.ofs).flatten.toList(_))
+
     // Figure out which read port was active in direct
     val directIds = p.directRMux.sortByMuxPortAndCombine.collect{case(muxAddr,entry) if (i < entry._1.length) => p.directRMux.accessParsBelowMuxPort(muxAddr._1,0).sum + i }
-    val directCandidates = directIds.map(io.directR(_))
-    // Create bit vector to select which bank was activated by this i
-    val sel = m.map{ case(mem,coords,flatCoord) => 
-      val xBarWants = if (xBarCandidates.toList.length > 0) xBarCandidates.map {x => 
-        x.banks.zip(coords).map{case (b, coord) => b === coord.U}.reduce{_&&_} && x.en
+    val directCandidatesEns = directIds.map(io.directR.map(_.en).flatten.toList(_))
+    val directCandidatesBanks = directIds.map(io.xBarR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
+    val directCandidatesOffsets = directIds.map(io.directR.map(_.ofs).flatten.toList(_))
+    // Create bit vector to select which bank was activated by this io
+    val sel = m.map{ mem => 
+      val xBarWants = if (xBarCandidatesEns.toList.length > 0) (xBarCandidatesEns, xBarCandidatesBanks, xBarCandidatesOffsets).zipped.map {case(en,banks,ofs) => 
+        banks.zip(mem._2).map{case (b, coord) => b === coord.U}.reduce{_&&_} && en
       }.reduce{_||_} else false.B
-      val directWants = if (directCandidates.toList.length > 0) directCandidates.map {x => 
-        x.banks.zip(coords).map{case (b, coord) => b == coord}.reduce{_&&_}.B && x.en
+      val directWants = if (directCandidatesEns.toList.length > 0) (directCandidatesEns, directCandidatesBanks, directCandidatesOffsets).zipped.map {case(en,banks,ofs) => 
+        banks.zip(mem._2).map{case (b, coord) => b == coord}.reduce{_&&_}.B && en
       }.reduce{_||_} else false.B
       xBarWants || directWants
     }
@@ -636,20 +675,26 @@ class LUT(p: MemParams) extends MemPrimitive(p) {
     (mem,coords,i)
   }
 
+  // Connect read data to output
   io.output.data.zipWithIndex.foreach { case (wire,i) => 
     // Figure out which read port was active in xBar
     val xBarIds = p.xBarRMux.sortByMuxPortAndCombine.collect{case(muxAddr,entry) if (i < entry._1) => p.xBarRMux.accessParsBelowMuxPort(muxAddr._1,0).sum + i }
-    val xBarCandidates = xBarIds.map(io.xBarR(_))
+    val xBarCandidatesEns = xBarIds.map(io.xBarR.map(_.en).flatten.toList(_))
+    val xBarCandidatesBanks = xBarIds.map(io.xBarR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
+    val xBarCandidatesOffsets = xBarIds.map(io.xBarR.map(_.ofs).flatten.toList(_))
+
     // Figure out which read port was active in direct
     val directIds = p.directRMux.sortByMuxPortAndCombine.collect{case(muxAddr,entry) if (i < entry._1.length) => p.directRMux.accessParsBelowMuxPort(muxAddr._1,0).sum + i }
-    val directCandidates = directIds.map(io.directR(_))
-    // Create bit vector to select which bank was activated by this i
-    val sel = m.map{ case(mem,coords,flatCoord) => 
-      val xBarWants = if (xBarCandidates.toList.length > 0) xBarCandidates.map {x => 
-        x.banks.zip(coords).map{case (b, coord) => b === coord.U}.reduce{_&&_} && x.en
+    val directCandidatesEns = directIds.map(io.directR.map(_.en).flatten.toList(_))
+    val directCandidatesBanks = directIds.map(io.xBarR.map(_.banks).flatten.toList.grouped(p.banks.length).toList(_))
+    val directCandidatesOffsets = directIds.map(io.directR.map(_.ofs).flatten.toList(_))
+    // Create bit vector to select which bank was activated by this io
+    val sel = m.map{ mem => 
+      val xBarWants = if (xBarCandidatesEns.toList.length > 0) (xBarCandidatesEns, xBarCandidatesBanks, xBarCandidatesOffsets).zipped.map {case(en,banks,ofs) => 
+        banks.zip(mem._2).map{case (b, coord) => b === coord.U}.reduce{_&&_} && en
       }.reduce{_||_} else false.B
-      val directWants = if (directCandidates.toList.length > 0) directCandidates.map {x => 
-        x.banks.zip(coords).map{case (b, coord) => b == coord}.reduce{_&&_}.B && x.en
+      val directWants = if (directCandidatesEns.toList.length > 0) (directCandidatesEns, directCandidatesBanks, directCandidatesOffsets).zipped.map {case(en,banks,ofs) => 
+        banks.zip(mem._2).map{case (b, coord) => b == coord}.reduce{_&&_}.B && en
       }.reduce{_||_} else false.B
       xBarWants || directWants
     }
@@ -668,9 +713,9 @@ class Mem1D(val size: Int, bitWidth: Int, syncMem: Boolean = false) extends Modu
   val addrWidth = Utils.log2Up(size)
 
   val io = IO( new Bundle {
-    val r = Input(new R_XBar(addrWidth, List(1)))
+    val r = Input(new R_XBar(1, addrWidth, List(1)))
     val rMask = Input(Bool())
-    val w = Input(new W_XBar(addrWidth, List(1), bitWidth))
+    val w = Input(new W_XBar(1, addrWidth, List(1), bitWidth))
     val wMask = Input(Bool())
     val flow = Input(Bool())
     val output = new Bundle {
@@ -687,24 +732,24 @@ class Mem1D(val size: Int, bitWidth: Int, syncMem: Boolean = false) extends Modu
 
   // We can do better than MaxJ by forcing mems to be single-ported since
   //   we know how to properly schedule reads and writes
-  val wInBound = io.w.ofs <= (size).U
-  val rInBound = io.r.ofs <= (size).U
+  val wInBound = io.w.ofs.head <= (size).U
+  val rInBound = io.r.ofs.head <= (size).U
 
   if (syncMem) {
     if (size <= Utils.SramThreshold) {
       val m = (0 until size).map{ i =>
         val reg = RegInit(0.U(bitWidth.W))
-        reg := Mux(io.w.en & (io.w.ofs === i.U(addrWidth.W)) & io.wMask, io.w.data, reg)
+        reg := Mux(io.w.en.head & (io.w.ofs.head === i.U(addrWidth.W)) & io.wMask, io.w.data.head, reg)
         (i.U(addrWidth.W) -> reg)
       }
-      val radder = Utils.getRetimed(io.r.ofs,1,io.flow)
+      val radder = Utils.getRetimed(io.r.ofs.head,1,io.flow)
       io.output.data := Utils.getRetimed(MuxLookup(radder, 0.U(bitWidth.W), m), 1, io.flow)
     } else {
       val m = Module(new fringe.SRAM(UInt(bitWidth.W), size, "Generic")) // TODO: Change to BRAM or URAM once we get SRAMVerilogAWS_BRAM/URAM.v
-      m.io.raddr     := Utils.getRetimed(io.r.ofs, 1, io.flow)
-      m.io.waddr     := io.w.ofs
-      m.io.wen       := io.w.en & wInBound & io.wMask
-      m.io.wdata     := io.w.data
+      m.io.raddr     := Utils.getRetimed(io.r.ofs.head, 1, io.flow)
+      m.io.waddr     := io.w.ofs.head
+      m.io.wen       := io.w.en.head & wInBound & io.wMask
+      m.io.wdata     := io.w.data.head
       m.io.flow      := io.flow
       io.output.data := m.io.rdata
     }
@@ -712,22 +757,22 @@ class Mem1D(val size: Int, bitWidth: Int, syncMem: Boolean = false) extends Modu
     if (size <= Utils.SramThreshold) {
       val m = (0 until size).map{ i =>
         val reg = RegInit(0.U(bitWidth.W))
-        reg := Mux(io.w.en & io.wMask & (io.w.ofs === i.U(addrWidth.W)), io.w.data, reg)
+        reg := Mux(io.w.en.head & io.wMask & (io.w.ofs.head === i.U(addrWidth.W)), io.w.data.head, reg)
         (i.U(addrWidth.W) -> reg)
       }
-      io.output.data := MuxLookup(io.r.ofs, 0.U(bitWidth.W), m)
+      io.output.data := MuxLookup(io.r.ofs.head, 0.U(bitWidth.W), m)
     } else {
       val m = Mem(size, UInt(bitWidth.W) /*, seqRead = true deprecated? */)
-      when (io.w.en & io.wMask & wInBound) {m(io.w.ofs) := io.w.data}
-      io.output.data := m(io.r.ofs)
+      when (io.w.en.head & io.wMask & wInBound) {m(io.w.ofs.head) := io.w.data.head}
+      io.output.data := m(io.r.ofs.head)
     }
   }
 
   if (scala.util.Properties.envOrElse("RUNNING_REGRESSION", "0") == "1") {
     io.debug.invalidRAddr := ~rInBound
     io.debug.invalidWAddr := ~wInBound
-    io.debug.rwOn := io.w.en & io.r.en & io.wMask & io.rMask
-    io.debug.error := ~rInBound | ~wInBound | (io.w.en & io.r.en & io.wMask & io.rMask)
+    io.debug.rwOn := io.w.en.head & io.r.en.head & io.wMask & io.rMask
+    io.debug.error := ~rInBound | ~wInBound | (io.w.en.head & io.r.en.head & io.wMask & io.rMask)
     // io.debug.addrProbe := m(0.U)
   }
 

--- a/resources/synth/chisel-templates/templates/MemPrimitives.scala
+++ b/resources/synth/chisel-templates/templates/MemPrimitives.scala
@@ -371,8 +371,8 @@ class FIFO(p: MemParams) extends MemPrimitive(p) {
   // Create bank counters
   val headCtr = Module(new CompactingCounter(p.numXBarW, p.depth, p.elsWidth))
   val tailCtr = Module(new CompactingCounter(p.numXBarR, p.depth, p.elsWidth))
-  (0 until p.numXBarW).foreach{i => headCtr.io.input.enables(i) := io.xBarW(i).en}
-  (0 until p.numXBarR).foreach{i => tailCtr.io.input.enables(i) := io.xBarR(i).en}
+  (0 until p.numXBarW).foreach{i => headCtr.io.input.enables.zip(io.xBarW.map(_.en)).foreach{case (l,r) => l := r}}
+  (0 until p.numXBarR).foreach{i => tailCtr.io.input.enables.zip(io.xBarR.map(_.en)).foreach{case (l,r) => l := r}}
   headCtr.io.input.reset := reset
   tailCtr.io.input.reset := reset
   headCtr.io.input.dir := true.B

--- a/resources/synth/chisel-templates/templates/NBuffers.scala
+++ b/resources/synth/chisel-templates/templates/NBuffers.scala
@@ -120,7 +120,7 @@ class NBufMem(val mem: MemType,
         val dBanks = if (hasDirectR) {
           directRMux.toSeq.sortBy(_._1).toMap.values.map(_.toSeq.sortBy(_._1).toMap.values.map(_._1)).flatten.toList(i) 
         } else defaultDirect
-        Input(new R_Direct(directWMux.accessPars.getOr1(i), ofsWidth, dBanks))
+        Input(new R_Direct(directRMux.accessPars.getOr1(i), ofsWidth, dBanks))
       })
     val broadcastW = HVec(Array.tabulate(1 max numBroadcastWPorts){i => Input(new W_XBar(broadcastWMux.accessPars.getOr1(i), ofsWidth, banksWidths, bitWidth))})
     val broadcastR = HVec(Array.tabulate(1 max numBroadcastRPorts){i => Input(new R_XBar(broadcastRMux.accessPars.getOr1(i), ofsWidth, banksWidths))})

--- a/resources/synth/chisel-templates/templates/NBuffers.scala
+++ b/resources/synth/chisel-templates/templates/NBuffers.scala
@@ -229,7 +229,7 @@ class NBufMem(val mem: MemType,
             // f.io.xBarR(bufferBase + k).data := io.xBarR(bufferBase + k).data
             f.io.xBarR(bufferBase + k).ofs := io.xBarR(bufferBase + k).ofs
             f.io.xBarR(bufferBase + k).banks.zip(io.xBarR(bufferBase+k).banks).foreach{case (a:UInt,b:UInt) => a := b}
-            f.io.flow(k) := io.flow(k) // Dangerous move here
+            f.io.flow(k + bufferBase) := io.flow(k + bufferBase) // Dangerous move here
           }
         }
 
@@ -248,10 +248,10 @@ class NBufMem(val mem: MemType,
               io.output.data(xBarRBase + bufferBase + (k_base + m)) := chisel3.util.Mux1H(outSel, srams.map{f => f.io.output.data(sram_index)})
             }
 
-            f.io.directR(bufferBase + k).en := io.directR(k).en.map(_ & rMask)
+            f.io.directR(bufferBase + k).en := io.directR(bufferBase + k).en.map(_ & rMask)
             // f.io.directR(bufferBase + k).data := io.directR(bufferBase + k).data
-            f.io.directR(bufferBase + k).ofs := io.directR(k).ofs
-            f.io.flow(k + numXBarR) := io.flow(k + numXBarR) // Dangerous move here
+            f.io.directR(bufferBase + k).ofs := io.directR(bufferBase + k).ofs
+            f.io.flow(k + bufferBase + numXBarR) := io.flow(k + bufferBase + numXBarR) // Dangerous move here
           }
         }
 

--- a/resources/synth/chisel-templates/templates/Types.scala
+++ b/resources/synth/chisel-templates/templates/Types.scala
@@ -44,6 +44,8 @@ class FixedPoint(val s: Boolean, val d: Int, val f: Int) extends Bundle {
 	def apply(msb:Int, lsb:Int): UInt = this.number(msb,lsb)
 	def apply(bit:Int): Bool = this.number(bit)
 
+    def toSeq: Seq[FixedPoint] = Seq(this)
+
 	// Properties
 	val number = UInt((d + f).W)
 	val debug_overflow = Bool()

--- a/resources/synth/chisel-templates/templates/Utils.scala
+++ b/resources/synth/chisel-templates/templates/Utils.scala
@@ -27,7 +27,16 @@ object ops {
       chisel3.util.Cat(b.map{_.raw}).FP(s, d, f)
     }
   }
+  implicit class SeqIntOps[T](val b:Seq[Int]) {
+    def getOr1(idx: Int): Int = if (b.size > idx) b(idx) else 1
+  }
+  implicit class SeqBoolOps[T](val b:Seq[Bool]) {
+    def or = if (b.size == 0) false.B else b.reduce{_||_}
+    def and = if (b.size == 0) true.B else b.reduce{_&&_}
+  }
   implicit class ArrayBoolOps[T](val b:Array[Bool]) {
+    def or = if (b.size == 0) false.B else b.reduce{_||_}
+    def and = if (b.size == 0) true.B else b.reduce{_&&_}
     def raw = chisel3.util.Cat(b.map{_.raw})
     def FP(s: Boolean, d: Int, f: Int): FixedPoint = {
       chisel3.util.Cat(b.map{_.raw}).FP(s, d, f)
@@ -50,6 +59,8 @@ object ops {
   }
 
   implicit class BoolOps(val b:Bool) {
+    def toSeq: Seq[Bool] = Seq(b)
+
     def D(delay: Int, retime_released: Bool): Bool = {
 //      Mux(retime_released, chisel3.util.ShiftRegister(b, delay, false.B, true.B), false.B)
       Mux(retime_released, Utils.getRetimed(b, delay), false.B)
@@ -88,6 +99,7 @@ object ops {
   // }
 
   implicit class UIntOps(val b:UInt) {
+    def toSeq: Seq[UInt] = Seq(b)
     // Define number so that we can be compatible with FixedPoint type
     def number = {
       b
@@ -296,6 +308,7 @@ object ops {
   }
 
   implicit class SIntOps(val b:SInt) {
+    def toSeq: Seq[SInt] = Seq(b)
     // Define number so that we can be compatible with FixedPoint type
     def number = {
       b.asUInt
@@ -524,6 +537,9 @@ object ops {
     def *-*(x: Long): Long = {b*x}
     def /-/(x: Long): Long = {b/x}
     def %-%(x: Long): Long = {b%x}
+    def indices[T](func: Int => T): Seq[T] = {
+      (0 until b).map{ i => func(i) }.toSeq
+    }
   }
 
   implicit class DoubleOps(val b: Double) {

--- a/resources/synth/chisel-templates/tests/templates/Memories.scala
+++ b/resources/synth/chisel-templates/tests/templates/Memories.scala
@@ -14,23 +14,23 @@ class Mem1DTests(c: Mem1D) extends PeekPokeTester(c) {
   step(1)
   reset(1)
   for (i <- 0 until c.size ) {
-    poke(c.io.w.ofs, i)
-    poke(c.io.w.data, i*2)
-    poke(c.io.w.en, 1)
+    poke(c.io.w.ofs.head, i)
+    poke(c.io.w.data.head, i*2)
+    poke(c.io.w.en.head, 1)
     poke(c.io.wMask, 1)
     step(1) 
-    poke(c.io.w.en, 0)
+    poke(c.io.w.en.head, 0)
     poke(c.io.wMask, 0)
     step(1)
   }
 
   for (i <- 0 until c.size ) {
-    poke(c.io.r.ofs, i)
-    poke(c.io.r.en, 1)
+    poke(c.io.r.ofs.head, i)
+    poke(c.io.r.en.head, 1)
     poke(c.io.rMask, 1)
     step(1)
     expect(c.io.output.data, i*2)
-    poke(c.io.r.en, 0)
+    poke(c.io.r.en.head, 0)
     poke(c.io.rMask, 0)
     step(1)
   }
@@ -39,17 +39,17 @@ class Mem1DTests(c: Mem1D) extends PeekPokeTester(c) {
 
 class FFTests(c: FF) extends PeekPokeTester(c) {
   val initval = 10
-  poke(c.io.xBarW(0).init, initval)
-  poke(c.io.xBarW(0).reset, 1)
+  poke(c.io.xBarW(0).init.head, initval)
+  poke(c.io.xBarW(0).reset.head, 1)
   reset(1)
   step(1)
   expect(c.io.output.data(0), initval)
-  poke(c.io.xBarW(0).reset, 0)
+  poke(c.io.xBarW(0).reset.head, 0)
   step(1)
 
   // overwrite init
-  poke(c.io.xBarW(0).data, 0)
-  poke(c.io.xBarW(0).en, 1)
+  poke(c.io.xBarW(0).data.head, 0)
+  poke(c.io.xBarW(0).en.head, 1)
   step(1)
   expect(c.io.output.data(0), 0)
   step(1)
@@ -58,8 +58,8 @@ class FFTests(c: FF) extends PeekPokeTester(c) {
   for (i <- 0 until numCycles) {
     val newenable = rnd.nextInt(2)
     val oldout = peek(c.io.output.data(0))
-    poke(c.io.xBarW(0).data, i)
-    poke(c.io.xBarW(0).en, newenable)
+    poke(c.io.xBarW(0).data.head, i)
+    poke(c.io.xBarW(0).en.head, newenable)
     step(1)
     if (newenable == 1) {
       // val a = peek(c.io.output.data(0))
@@ -71,8 +71,8 @@ class FFTests(c: FF) extends PeekPokeTester(c) {
       expect(c.io.output.data(0), oldout)
     }
   }
-  poke(c.io.xBarW(0).reset, 1)
-  poke(c.io.xBarW(0).en, 0)
+  poke(c.io.xBarW(0).reset.head, 1)
+  poke(c.io.xBarW(0).en.head, 0)
   // val b = peek(c.io.output.data(0))
   // println(s"expect $b to be $initval ? ${b == initval}")
   step(1)
@@ -81,7 +81,7 @@ class FFTests(c: FF) extends PeekPokeTester(c) {
   // val cc = peek(c.io.output.data(0))
   // println(s"expect $cc to be $initval ? ${cc == initval}")
   expect(c.io.output.data(0), initval)
-  poke(c.io.xBarW(0).reset, 0)
+  poke(c.io.xBarW(0).reset.head, 0)
   step(1)
   // val d = peek(c.io.output.data(0))
   // println(s"expect $d to be $initval ? ${d == initval}")
@@ -97,12 +97,12 @@ class ShiftRegFileTests(c: ShiftRegFile) extends PeekPokeTester(c) {
       for (j <- 0 until c.p.logicalDims(1)) {
         poke(c.io.xBarW(0).banks(0), i)
         poke(c.io.xBarW(0).banks(1), j)
-        poke(c.io.xBarW(0).data, i+j)
-        poke(c.io.xBarW(0).en, 1)
+        poke(c.io.xBarW(0).data.head, i+j)
+        poke(c.io.xBarW(0).en.head, 1)
         step(1)
       }
     }
-    poke(c.io.xBarW(0).en, 0)
+    poke(c.io.xBarW(0).en.head, 0)
     step(1)
 
     // Read RegFile
@@ -110,7 +110,7 @@ class ShiftRegFileTests(c: ShiftRegFile) extends PeekPokeTester(c) {
       for (j <- 0 until c.p.logicalDims(1)) {
         poke(c.io.xBarR(0).banks(0), i)
         poke(c.io.xBarR(0).banks(1), j)
-        poke(c.io.xBarR(0).en, 1)
+        poke(c.io.xBarR(0).en.head, 1)
         expect(c.io.output.data(0), i+j)
         step(1)
       }
@@ -121,14 +121,14 @@ class ShiftRegFileTests(c: ShiftRegFile) extends PeekPokeTester(c) {
       for (i <- 0 until c.p.logicalDims(0)) {
         poke(c.io.xBarW(0).banks(0), i)
         poke(c.io.xBarW(0).banks(1), 0)
-        poke(c.io.xBarW(0).data, i+wavefront*10)
-        poke(c.io.xBarW(0).shiftEn, 1)
-        poke(c.io.xBarW(0).en, 1)
+        poke(c.io.xBarW(0).data.head, i+wavefront*10)
+        poke(c.io.xBarW(0).shiftEn.head, 1)
+        poke(c.io.xBarW(0).en.head, 1)
         step(1)
       }
 
-      poke(c.io.xBarW(0).en, 0)
-      poke(c.io.xBarW(0).shiftEn, 0)
+      poke(c.io.xBarW(0).en.head, 0)
+      poke(c.io.xBarW(0).shiftEn.head, 0)
       step(1)
 
 
@@ -137,7 +137,7 @@ class ShiftRegFileTests(c: ShiftRegFile) extends PeekPokeTester(c) {
         for (j <- 0 until c.p.logicalDims(1)) {
           poke(c.io.xBarR(0).banks(0), i)
           poke(c.io.xBarR(0).banks(1), j)
-          poke(c.io.xBarR(0).en, 1)
+          poke(c.io.xBarR(0).en.head, 1)
           // if (j < wavefront) expect(c.io.output.data(i), 0)
           // else expect(c.io.output.data(i), 0)
           val d = peek(c.io.output.data(0))
@@ -173,16 +173,16 @@ class SRAMTests(c: SRAM) extends PeekPokeTester(c) {
         val kdim = ii * c.p.banks(1) + jj
         // poke(c.io.directW(kdim).banks(0), i % c.p.banks(0))
         // poke(c.io.directW(kdim).banks(1), (j+kdim) % c.p.banks(1))
-        poke(c.io.directW(kdim).ofs, (i+ii) / c.p.banks(0) * (c.p.logicalDims(1) / c.p.banks(1)) + (j+jj) / c.p.banks(1))
-        poke(c.io.directW(kdim).data, (i*c.p.logicalDims(0) + j + kdim)*2)
-        poke(c.io.directW(kdim).en, true)
+        poke(c.io.directW.head.ofs(kdim), (i+ii) / c.p.banks(0) * (c.p.logicalDims(1) / c.p.banks(1)) + (j+jj) / c.p.banks(1))
+        poke(c.io.directW.head.data(kdim), (i*c.p.logicalDims(0) + j + kdim)*2)
+        poke(c.io.directW.head.en(kdim), true)
       }}
       step(1)
     }
   }
   // Turn off wEn
   (0 until wPar).foreach{ kdim => 
-    poke(c.io.directW(kdim).en, false)
+    poke(c.io.directW.head.en(kdim), false)
   }
 
   step(30)
@@ -196,8 +196,8 @@ class SRAMTests(c: SRAM) extends PeekPokeTester(c) {
         val kdim = ii * c.p.banks(1) + jj
         // poke(c.io.directR(kdim).banks(0), i % c.p.banks(0))
         // poke(c.io.directR(kdim).banks(1), (j+kdim) % c.p.banks(1))
-        poke(c.io.directR(kdim).ofs, (i+ii) / c.p.banks(0) * (c.p.logicalDims(1) / c.p.banks(1)) + (j+jj) / c.p.banks(1))
-        poke(c.io.directR(kdim).en, true)
+        poke(c.io.directR.head.ofs(kdim), (i+ii) / c.p.banks(0) * (c.p.logicalDims(1) / c.p.banks(1)) + (j+jj) / c.p.banks(1))
+        poke(c.io.directR.head.en(kdim), true)
       }}
       step(1)
       (0 until rPar).foreach { kdim => 
@@ -207,7 +207,7 @@ class SRAMTests(c: SRAM) extends PeekPokeTester(c) {
   }
   // Turn off rEn
   (0 until rPar).foreach{ reader => 
-    poke(c.io.directR(reader).en, false)
+    poke(c.io.directR.head.en(reader), false)
   }
 
   step(1)
@@ -234,24 +234,24 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
           (0 until c.banks(0)).foreach{ ii => (0 until c.banks(1)).foreach{ jj =>
             poke(c.io.broadcastW(0).banks(0), ii)
             poke(c.io.broadcastW(0).banks(1), jj)
-            poke(c.io.broadcastW(0).ofs, (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
-            poke(c.io.broadcastW(0).data, 999)
-            poke(c.io.broadcastW(0).en, true)
+            poke(c.io.broadcastW(0).ofs.head, (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
+            poke(c.io.broadcastW(0).data.head, 999)
+            poke(c.io.broadcastW(0).en.head, true)
             step(1)      
           }}
         }
       }
     case FFType => 
-      poke(c.io.broadcastW(0).data, 999)
-      poke(c.io.broadcastW(0).en, true)
+      poke(c.io.broadcastW(0).data.head, 999)
+      poke(c.io.broadcastW(0).en.head, true)
       step(1)
     case ShiftRegFileType => 
       for (i <- 0 until c.logicalDims(0)) {
         for (j <- 0 until c.logicalDims(1)) {
           poke(c.io.broadcastW(0).banks(0), i)
           poke(c.io.broadcastW(0).banks(1), j)
-          poke(c.io.broadcastW(0).data, 999)
-          poke(c.io.broadcastW(0).en, true)
+          poke(c.io.broadcastW(0).data.head, 999)
+          poke(c.io.broadcastW(0).en.head, true)
           step(1)      
         }
       }
@@ -259,7 +259,7 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
     case LIFOType =>
     case LineBufferType => 
   }
-  c.io.broadcastW.foreach{p => poke(p.en, false)}
+  c.io.broadcastW.foreach{p => poke(p.en.head, false)}
   step(1)
 
   // Read all bufs
@@ -276,8 +276,8 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
               val kdim = ii * c.banks(1) + jj
               // poke(c.io.directR(kdim).banks(0), i % c.banks(0))
               // poke(c.io.directR(kdim).banks(1), (j+kdim) % c.banks(1))
-              poke(c.io.directR(kdim).ofs, (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
-              poke(c.io.directR(kdim).en, true)
+              poke(c.io.directR.head.ofs(kdim), (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
+              poke(c.io.directR.head.en(kdim), true)
             }}
             step(1)
             (0 until rPar).foreach { kdim => 
@@ -294,7 +294,7 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
           for (j <- 0 until c.logicalDims(1)) {
             poke(c.io.xBarR(0).banks(0), i)
             poke(c.io.xBarR(0).banks(1), j)
-            poke(c.io.xBarR(0).en, true)
+            poke(c.io.xBarR(0).en.head, true)
             expect(c.io.output.data(0),999)
             val x = peek(c.io.output.data(0))
             print(" " + x)
@@ -307,7 +307,7 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
       case LineBufferType => 
 
     }
-    c.io.directR.foreach{p => poke(p.en, false)}
+    c.io.directR.foreach{p => poke(p.en.head, false)}
     // Rotate buffer
     poke(c.io.sEn(0), 1)
     step(1)
@@ -333,24 +333,24 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
               val kdim = ii * c.banks(1) + jj
               // poke(c.io.directW(kdim).banks(0), i % c.banks(0))
               // poke(c.io.directW(kdim).banks(1), (j+kdim) % c.banks(1))
-              poke(c.io.directW(kdim).ofs, (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
-              poke(c.io.directW(kdim).data, epoch*100 + (i*c.logicalDims(0) + j + kdim)*2)
-              poke(c.io.directW(kdim).en, 1)
+              poke(c.io.directW.head.ofs(kdim), (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
+              poke(c.io.directW.head.data(kdim), epoch*100 + (i*c.logicalDims(0) + j + kdim)*2)
+              poke(c.io.directW.head.en(kdim), 1)
             }}
             step(1)
           }
         }
       case FFType => 
-        poke(c.io.xBarW(0).data, epoch*100)
-        poke(c.io.xBarW(0).en, true)
+        poke(c.io.xBarW(0).data.head, epoch*100)
+        poke(c.io.xBarW(0).en.head, true)
         step(1)
       case ShiftRegFileType => 
         for (i <- 0 until c.logicalDims(0)) {
           for (j <- 0 until c.logicalDims(1)) {
             poke(c.io.xBarW(0).banks(0), i)
             poke(c.io.xBarW(0).banks(1), j)
-            poke(c.io.xBarW(0).data, epoch*100 + (i*c.logicalDims(0)+j)*2)
-            poke(c.io.xBarW(0).en, true)
+            poke(c.io.xBarW(0).data.head, epoch*100 + (i*c.logicalDims(0)+j)*2)
+            poke(c.io.xBarW(0).en.head, true)
             step(1)      
           }
         }
@@ -361,8 +361,8 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
     }
 
     // Turn off wEn
-    c.io.directW.foreach{p => poke(p.en, false)}
-    c.io.xBarW.foreach{p => poke(p.en, false)}
+    c.io.directW.foreach{p => poke(p.en.head, false)}
+    c.io.xBarW.foreach{p => poke(p.en.head, false)}
 
     step(30)
 
@@ -389,8 +389,8 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
               val kdim = ii * c.banks(1) + jj
               // poke(c.io.directR(kdim).banks(0), i % c.banks(0))
               // poke(c.io.directR(kdim).banks(1), (j+kdim) % c.banks(1))
-              poke(c.io.directR(kdim).ofs, (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
-              poke(c.io.directR(kdim).en, 1)
+              poke(c.io.directR.head.ofs(kdim), (i+ii) / c.banks(0) * (c.logicalDims(1) / c.banks(1)) + (j+jj) / c.banks(1))
+              poke(c.io.directR.head.en(kdim), 1)
             }}
             step(1)
             (0 until rPar).foreach { kdim => 
@@ -421,7 +421,7 @@ class NBufMemTests(c: NBufMem) extends PeekPokeTester(c) {
     println("")
     
     // Turn off rEn
-    c.io.directR.foreach{p => poke(p.en, false)}
+    c.io.directR.foreach{p => poke(p.en.head, false)}
 
     step(1)
   }
@@ -438,15 +438,15 @@ class FIFOTests(c: FIFO) extends PeekPokeTester(c) {
 
   var fifo = scala.collection.mutable.Queue[Int]()
   def enq(datas: Seq[Int], ens: Seq[Int]): Unit = {
-    (0 until datas.length).foreach { i => poke(c.io.xBarW(i).data, datas(i)) }
-    (0 until datas.length).foreach { i => poke(c.io.xBarW(i).en, ens(i)) }
+    (0 until datas.length).foreach { i => poke(c.io.xBarW.head.data(i), datas(i)) }
+    (0 until datas.length).foreach { i => poke(c.io.xBarW.head.en(i), ens(i)) }
     step(1)
-    (0 until datas.length).foreach { i => poke(c.io.xBarW(i).en, 0) }
+    (0 until datas.length).foreach { i => poke(c.io.xBarW.head.en(i), 0) }
     step(1)
     (0 until datas.length).foreach{i => if (ens(i) != 0) fifo.enqueue(datas(i))}
   }
   def deq(ens: Seq[Int]): Unit = {
-    (0 until ens.length).foreach { i => poke(c.io.xBarR(i).en, ens(i)) }
+    (0 until ens.length).foreach { i => poke(c.io.xBarR.head.en(i), ens(i)) }
     val num_popping = ens.reduce{_+_}
     (0 until ens.length).foreach{i => 
       val out = peek(c.io.output.data(i))
@@ -456,7 +456,7 @@ class FIFOTests(c: FIFO) extends PeekPokeTester(c) {
       }
     }
     step(1)
-    (0 until ens.length).foreach{ i => poke(c.io.xBarR(i).en,0)}
+    (0 until ens.length).foreach{ i => poke(c.io.xBarR.head.en(i),0)}
   }
 
   // fill FIFO halfway

--- a/src/spatial/codegen/chiselgen/ChiselCodegen.scala
+++ b/src/spatial/codegen/chiselgen/ChiselCodegen.scala
@@ -118,25 +118,25 @@ trait ChiselCodegen extends NamedCodegen with FileDependencies with AccelTravers
       val extractor(d,w) = rhs
       s"${vec}ff${d}_${w}"
     } else if (rhs.contains(" W_Direct(")) {
-      val extractor = ".*W_Direct\\([ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*,[ ]*([0-9]+)[ ]*\\).*".r
-      val extractor(ofsW,bankWs,dW) = rhs
+      val extractor = ".*W_Direct\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*,[ ]*([0-9]+)[ ]*\\).*".r
+      val extractor(pw,ofsW,bankWs,dW) = rhs
       val bWs = bankWs.replace(" ", "").replace(",","_")
-      s"${vec}wdbar${ofsW}_${bWs}_${dW}"
+      s"${vec}wdbar${pw}_${ofsW}_${bWs}_${dW}"
     } else if (rhs.contains(" R_Direct(")) {
-      val extractor = ".*R_Direct\\([ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*\\).*".r
-      val extractor(ofsW,bankWs) = rhs
+      val extractor = ".*R_Direct\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*\\).*".r
+      val extractor(pw,ofsW,bankWs) = rhs
       val bWs = bankWs.replace(" ", "").replace(",","_")
-      s"${vec}rdbar${ofsW}_${bWs}"
+      s"${vec}rdbar${pw}_${ofsW}_${bWs}"
     } else if (rhs.contains(" W_XBar(")) {
-      val extractor = ".*W_XBar\\([ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*,[ ]*([0-9]+)[ ]*\\).*".r
-      val extractor(ofsW,bankWs,dW) = rhs
+      val extractor = ".*W_XBar\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*,[ ]*([0-9]+)[ ]*\\).*".r
+      val extractor(pw,ofsW,bankWs,dW) = rhs
       val bWs = bankWs.replace(" ", "").replace(",","_")
-      s"${vec}wxbar${ofsW}_${bWs}_${dW}"
+      s"${vec}wxbar${pw}_${ofsW}_${bWs}_${dW}"
     } else if (rhs.contains(" R_XBar(")) {
-      val extractor = ".*R_XBar\\([ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*\\).*".r
-      val extractor(ofsW,bankWs) = rhs
+      val extractor = ".*R_XBar\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*\\).*".r
+      val extractor(pw,ofsW,bankWs) = rhs
       val bWs = bankWs.replace(" ", "").replace(",","_")
-      s"${vec}rxbar${ofsW}_${bWs}"
+      s"${vec}rxbar${pw}_${ofsW}_${bWs}"
     } else if (rhs.contains(" RegChainPass(")) {
       val extractor = ".*RegChainPass\\([ ]*([0-9]+)[ ]*,[ ]*([0-9,]+)[ ]*\\).*".r
       val extractor(depth,width) = rhs

--- a/src/spatial/codegen/chiselgen/ChiselCodegen.scala
+++ b/src/spatial/codegen/chiselgen/ChiselCodegen.scala
@@ -17,7 +17,7 @@ trait ChiselCodegen extends NamedCodegen with FileDependencies with AccelTravers
   var streamLines = collection.mutable.Map[String, Int]() // Map from filename number of lines it has
   var streamExtensions = collection.mutable.Map[String, Int]() // Map from filename to number of extensions it has
   val tabWidth: Int = 2
-  val maxLinesPerFile = 400
+  val maxLinesPerFile = 200
   var compressorMap = collection.mutable.HashMap[String, (String,Int)]()
   var retimeList = collection.mutable.ListBuffer[String]()
   val pipeRtMap = collection.mutable.HashMap[(String,Int), String]()

--- a/src/spatial/codegen/chiselgen/ChiselCodegen.scala
+++ b/src/spatial/codegen/chiselgen/ChiselCodegen.scala
@@ -118,12 +118,12 @@ trait ChiselCodegen extends NamedCodegen with FileDependencies with AccelTravers
       val extractor(d,w) = rhs
       s"${vec}ff${d}_${w}"
     } else if (rhs.contains(" W_Direct(")) {
-      val extractor = ".*W_Direct\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*,[ ]*([0-9]+)[ ]*\\).*".r
+      val extractor = ".*W_Direct\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\).grouped\\([0-9]+\\).toList[ ]*,[ ]*([0-9]+)[ ]*\\).*".r
       val extractor(pw,ofsW,bankWs,dW) = rhs
       val bWs = bankWs.replace(" ", "").replace(",","_")
       s"${vec}wdbar${pw}_${ofsW}_${bWs}_${dW}"
     } else if (rhs.contains(" R_Direct(")) {
-      val extractor = ".*R_Direct\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\)[ ]*\\).*".r
+      val extractor = ".*R_Direct\\([ ]*([0-9]+)[ ]*,[ ]*([0-9]+)[ ]*,[ ]*List\\(([0-9,]+)\\).grouped\\([0-9]+\\).toList[ ]*\\).*".r
       val extractor(pw,ofsW,bankWs) = rhs
       val bWs = bankWs.replace(" ", "").replace(",","_")
       s"${vec}rdbar${pw}_${ofsW}_${bWs}"

--- a/src/spatial/codegen/chiselgen/ChiselGenMem.scala
+++ b/src/spatial/codegen/chiselgen/ChiselGenMem.scala
@@ -64,7 +64,6 @@ trait ChiselGenMem extends ChiselGenCommon {
                       else mem.instance.nBanks.map{x => Math.ceil(scala.math.log(x)/scala.math.log(2)).toInt}
     val isBroadcast = lhs.ports(0).values.head.bufferPort.isEmpty & mem.instance.depth > 1
     val bufferPort = lhs.ports(0).values.head.bufferPort.getOrElse(-1)
-    // val issue35hack = if (mem.instance.depth == 1 & lhs.ports(0).values.head.bufferPort.isEmpty) -1 else 0
     val muxPort = lhs.ports(0).values.head.muxPort
     val muxOfs = lhs.ports(0).values.head.muxOfs
 

--- a/src/spatial/codegen/chiselgen/ChiselGenMem.scala
+++ b/src/spatial/codegen/chiselgen/ChiselGenMem.scala
@@ -35,7 +35,7 @@ trait ChiselGenMem extends ChiselGenCommon {
     }
 
     if (lhs.isDirectlyBanked & !isBroadcast) {
-      emitGlobalWireMap(src"""${lhs}_port""", s"Wire(new R_Direct(${ens.length}, $ofsWidth, ${bank.flatten.map(_.trace.toInt)}.toList.grouped(${bank.head.length}).toList))") 
+      emitGlobalWireMap(src"""${lhs}_port""", s"Wire(new R_Direct(${ens.length}, $ofsWidth, ${bank.flatten.map(_.trace.toInt).mkString("List(",",",")")}.grouped(${bank.head.length}).toList))") 
       emitt(src"""${lhs}.toSeq.zip(${mem}.connectDirectRPort(${swap(src"${lhs}_port", Blank)}, $bufferPort, ($muxPort, $muxOfs) $flowEnable)).foreach{case (left, right) => left.r := right}""")
     } else if (isBroadcast) {
       val bankString = bank.flatten.map(quote(_) + ".r").mkString("List[UInt](", ",", ")")
@@ -69,7 +69,7 @@ trait ChiselGenMem extends ChiselGenCommon {
 
     val enport = if (shiftAxis.isDefined) "shiftEn" else "en"
     if (lhs.isDirectlyBanked && !isBroadcast) {
-      emitGlobalWireMap(src"""${lhs}_port""", s"Wire(new W_Direct(${data.length}, $ofsWidth, ${bank.flatten.map(_.trace.toInt)}.toList.grouped(${bank.head.length}).toList, $width))") 
+      emitGlobalWireMap(src"""${lhs}_port""", s"Wire(new W_Direct(${data.length}, $ofsWidth, ${bank.flatten.map(_.trace.toInt).mkString("List(",",",")")}.grouped(${bank.head.length}).toList, $width))") 
       emitt(src"""${mem}.connectDirectWPort(${swap(src"${lhs}_port", Blank)}, $bufferPort, (${muxPort}, $muxOfs))""")
     } else if (isBroadcast) {
       val bankString = bank.flatten.map(quote(_) + ".r").mkString("List[UInt](", ",", ")")

--- a/src/spatial/codegen/chiselgen/ChiselGenMem.scala
+++ b/src/spatial/codegen/chiselgen/ChiselGenMem.scala
@@ -83,7 +83,7 @@ trait ChiselGenMem extends ChiselGenCommon {
       emitt(src"""${mem}.connectXBarWPort(${swap(src"${lhs}_port", Blank)}, $bufferPort, (${muxPort}, $muxOfs))""")
     }
     val ensString = ens.map{e => and(e)}.mkString("List(",",",")")
-    emitt(src"""${swap(src"${lhs}_port", Blank)}.en.zip(${ensString}.toSeq.map(_ && ${invisibleEnable})).foreach{case (left, right) => left := right}""")
+    emitt(src"""${swap(src"${lhs}_port", Blank)}.$enport.zip(${ensString}.toSeq.map(_ && ${invisibleEnable})).foreach{case (left, right) => left := right}""")
     if (ofs.nonEmpty) emitt(src"""${swap(src"${lhs}_port", Blank)}.ofs.zip(${ofs.map(quote(_) + ".r").mkString("List[UInt](",",",")")}.toSeq.map(_.rd)).foreach{case (left, right) => left.r := right}""")
     emitt(src"""${swap(src"${lhs}_port", Blank)}.data.zip(${data.map(quote(_) + ".r").mkString("List[UInt](",",",")")}).foreach{case (left, right) => left.r := right}""")
   }

--- a/src/spatial/transform/RewriteTransformer.scala
+++ b/src/spatial/transform/RewriteTransformer.scala
@@ -21,13 +21,9 @@ case class RewriteTransformer(IR: State) extends MutateTransformer with AccelTra
     implicit val S: BOOL[S] = x.fmt.s
     implicit val I: INT[I] = x.fmt.i
     implicit val F: INT[F] = x.fmt.f
-    // val data = x.asBits
     if (log2(y.toDouble) == 0) x.from(0)
-    else {
-      // val range = (log2(y.toDouble)-1).toInt :: 0
-      // val selected = data.apply(range)
-      x.asUnchecked[Fix[S,I,F]]
-    }
+    // TODO: Consider making a node like case class BitRemap(data: Bits[_], remap: Seq[Int], outType: Bits[T]) that wouldn't add to retime latency
+    else x & (scala.math.pow(2,log2(y.toDouble))-1).to[Fix[S,I,F]] 
   }
 
   def writeReg[A](lhs: Sym[_], reg: Reg[_], data: Bits[A], ens: Set[Bit]): Void = {

--- a/src/spatial/transform/RewriteTransformer.scala
+++ b/src/spatial/transform/RewriteTransformer.scala
@@ -21,12 +21,12 @@ case class RewriteTransformer(IR: State) extends MutateTransformer with AccelTra
     implicit val S: BOOL[S] = x.fmt.s
     implicit val I: INT[I] = x.fmt.i
     implicit val F: INT[F] = x.fmt.f
-    val data = x.asBits
+    // val data = x.asBits
     if (log2(y.toDouble) == 0) x.from(0)
     else {
-      val range = (log2(y.toDouble)-1).toInt :: 0
-      val selected = data.apply(range)
-      selected.asUnchecked[Fix[S,I,F]]
+      // val range = (log2(y.toDouble)-1).toInt :: 0
+      // val selected = data.apply(range)
+      x.asUnchecked[Fix[S,I,F]]
     }
   }
 

--- a/test/spatial/tests/feature/control/PipelinedSimple.scala
+++ b/test/spatial/tests/feature/control/PipelinedSimple.scala
@@ -1,0 +1,43 @@
+package spatial.tests.feature.control
+
+
+import spatial.dsl._
+
+@spatial class SimplePipelined extends SpatialTest { 
+  override def runtimeArgs: Args = "3"
+
+
+
+  def main(args: Array[String]): Void = {
+    val xIn = args(0).to[Int]
+    val tileSize = 16
+
+    val x = ArgIn[Int]
+    val out1 = ArgOut[Int]
+    val out2 = ArgOut[Int]
+    val out3 = ArgOut[Int]
+    setArg(x, xIn)
+
+    Accel {
+      val bram = SRAM[Int](tileSize)
+      Foreach(tileSize by 1){ ii => bram(ii) = ii }
+      Foreach(tileSize by 1){ ii => 
+        val grab = ii === x.value
+        val used_val = x.value + ii
+        val ctrval = x.value * ii
+        'USECTRVAL1.Foreach(ctrval by 1){i => out2 := i}
+        'USECTRVAL2.Foreach(ctrval by 1){i => out2 := i}
+        if (grab) 'USEGRAB1.Foreach(3 by 1){i => out1 := bram(ii) + used_val}
+        Pipe{out2 := bram(ii)}
+        if (grab) 'USEGRAB2.Foreach(3 by 1){i => out3 := bram(ii) + used_val}
+      }
+    }
+
+    println(r"Got:      $out1 $out2 $out3")
+    println(r"Expected: ${3*xIn} 15 ${3*xIn}")
+
+    val chkSum = out1.value == 3*xIn && out2.value == 15 && out3.value == 3*xIn
+    assert(chkSum)
+    println("PASS: " + chkSum + " (SimplePip)")
+  }
+}

--- a/tests.sh
+++ b/tests.sh
@@ -72,20 +72,24 @@ elif [[ $type == "arria10" ]]; then
 elif [[ $type == "vcs-gdocs" ]]; then
   export GDOCS=1
   hash=`git rev-parse HEAD`
+  branchname=`git rev-parse --abbrev-ref HEAD | sed -i "s/HEAD/unknown/g"`
   export timestamp=`git show -s --format=%ci`
   curpath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   echo $hash > ${curpath}/reghash
-  echo "python3 ${curpath}/resources/regression/gdocs.py \"prepare_sheet\" \"$hash\" \"nova-spatial\" \"$timestamp\" \"vcs\""
-  python3 ${curpath}/resources/regression/gdocs.py "prepare_sheet" "$hash" "nova-spatial" "$timestamp" "vcs"
+  echo $branchname > ${curpath}/branchname
+  echo "python3 ${curpath}/resources/regression/gdocs.py \"prepare_sheet\" \"$hash\" \"$branchname\" \"$timestamp\" \"vcs\""
+  python3 ${curpath}/resources/regression/gdocs.py "prepare_sheet" "$hash" "$branchname" "$timestamp" "vcs"
   nice -n 20 sbt -Dmaxthreads=$threads -Dtest.VCS=true "testOnly $tests" 2>&1 | tee $fileout
   python3 ${curpath}/resources/regression/gdocs.py "report_changes" "vcs"
 elif [[ $type == "vcs-noretime-gdocs" ]]; then
   export GDOCS=1
   hash=`git rev-parse HEAD`
+  branchname=`git rev-parse --abbrev-ref HEAD | sed -i "s/HEAD/unknown/g"`
   export timestamp=`git show -s --format=%ci`
   curpath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   echo $hash > ${curpath}/reghash
-  python3 ${curpath}/resources/regression/gdocs.py "prepare_sheet" "$hash" "nova-spatial" "$timestamp" "vcs-noretime"
+  echo $branchname > ${curpath}/branchname
+  python3 ${curpath}/resources/regression/gdocs.py "prepare_sheet" "$hash" "$branchname" "$timestamp" "vcs-noretime"
   nice -n 20 sbt -Dmaxthreads=$threads -Dtest.VCS_noretime=true "testOnly $tests" 2>&1 | tee $fileout
   python3 ${curpath}/resources/regression/gdocs.py "report_changes" "vcs-noretime"
 else

--- a/tests.sh
+++ b/tests.sh
@@ -72,7 +72,7 @@ elif [[ $type == "arria10" ]]; then
 elif [[ $type == "vcs-gdocs" ]]; then
   export GDOCS=1
   hash=`git rev-parse HEAD`
-  branchname=`git rev-parse --abbrev-ref HEAD | sed -i "s/HEAD/unknown/g"`
+  branchname=`git rev-parse --abbrev-ref HEAD | sed "s/HEAD/unknown/g"`
   export timestamp=`git show -s --format=%ci`
   curpath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   echo $hash > ${curpath}/reghash
@@ -84,7 +84,7 @@ elif [[ $type == "vcs-gdocs" ]]; then
 elif [[ $type == "vcs-noretime-gdocs" ]]; then
   export GDOCS=1
   hash=`git rev-parse HEAD`
-  branchname=`git rev-parse --abbrev-ref HEAD | sed -i "s/HEAD/unknown/g"`
+  branchname=`git rev-parse --abbrev-ref HEAD | sed "s/HEAD/unknown/g"`
   export timestamp=`git show -s --format=%ci`
   curpath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   echo $hash > ${curpath}/reghash


### PR DESCRIPTION
Contains lots of modifications to chisel templates and the way ChiselGenMem works. Instead of breaking a parallelized access into a bunch of individual ports, the ports (w_direct/r_direct/w_xBar/r_xBar).

Also the rewrite rule for FixMod doesn't use the .asBits .asData stuff anymore to reduce the number of nodes in the IR.  It just masks out the appropriate bits with &, which may add a tiny amount of latency but I didn't feel like making a whole new node just for this.  You can change if you want