### PR TITLE
Issue155 memreduce

### DIFF
--- a/argon/src/argon/transform/Transformer.scala
+++ b/argon/src/argon/transform/Transformer.scala
@@ -194,14 +194,17 @@ abstract class Transformer extends Pass with TransformerInterface {
   }
   implicit class Lambda1Ops[A,R](lambda1: Lambda1[A,R]) {
     /** Inline all statements in the block into the current scope with the given input. */
-    def reapply(a: A): R = { val func = lambda1ToFunction1(lambda1); func(a) }
+    def reapply(a: A): R = { 
+      val func = lambda1ToFunction1(lambda1)
+      dbgs(s"Executing Function1 with inputs: $a")
+      func(a) 
+    }
     /** Turn this block into a callable Function1, where each call will reapply the Lambda. */
     def toFunction1: A => R = lambda1ToFunction1(lambda1)
   }
   implicit class Lambda2Ops[A,B,R](lambda2: Lambda2[A,B,R]) {
     /** Inline all statements in the block into the current scope with the given inputs. */
     def reapply(a: A, b: B): R = {
-      dbgs(s"Making Function2")
       val func = lambda2ToFunction2(lambda2)
       dbgs(s"Executing Function2 with inputs: $a and $b")
       func(a,b)
@@ -209,7 +212,11 @@ abstract class Transformer extends Pass with TransformerInterface {
     def toFunction2: (A, B) => R = lambda2ToFunction2(lambda2)
   }
   implicit class Lambda3Ops[A,B,C,R](lambda3: Lambda3[A,B,C,R]) {
-    def reapply(a: A, b: B, c: C): R = { val func = lambda3ToFunction3(lambda3); func(a,b,c) }
+    def reapply(a: A, b: B, c: C): R = { 
+      val func = lambda3ToFunction3(lambda3)
+      dbgs(s"Executing Function3 with inputs: $a, $b, and $c")
+      func(a,b,c)
+    }
     def toFunction3: (A, B, C) => R = lambda3ToFunction3(lambda3)
   }
 

--- a/src/spatial/Spatial.scala
+++ b/src/spatial/Spatial.scala
@@ -371,6 +371,10 @@ trait Spatial extends Compiler with ParamLoader {
       spatialConfig.target.areaModel.init()
       spatialConfig.target.latencyModel.init()
     }
+    if (java.nio.file.Files.exists(java.nio.file.Paths.get(config.genDir))) {
+      warn(s"Output directory ${config.genDir} already exists!  Generated files")
+      warn(s"from other targets may still exist and may interfere with this build!")
+    }
   }
 
 }

--- a/src/spatial/codegen/chiselgen/ChiselGenController.scala
+++ b/src/spatial/codegen/chiselgen/ChiselGenController.scala
@@ -23,7 +23,7 @@ trait ChiselGenController extends ChiselGenCommon {
   final private def enterCtrl(lhs: Sym[_]): Sym[_] = {
     val parent = if (controllerStack.isEmpty) lhs else controllerStack.head
     controllerStack.push(lhs)
-    if (spatialConfig.enableInstrumentation) instrumentCounters = instrumentCounters :+ (lhs, controllerStack.length)
+    if (spatialConfig.enableInstrumentation && inHw) instrumentCounters = instrumentCounters :+ (lhs, controllerStack.length)
     val cchain = if (lhs.cchains.isEmpty) "" else s"${lhs.cchains.head}"
     if (lhs.isOuterControl)      { widthStats += lhs.children.filter(_.s.get != lhs).toList.length }
     else if (lhs.isInnerControl) { depthStats += controllerStack.length }

--- a/src/spatial/metadata/memory/package.scala
+++ b/src/spatial/metadata/memory/package.scala
@@ -23,9 +23,11 @@ package object memory {
     def getIterDiff: Option[Int] = metadata[IterDiff](s).map(_.diff)
     def iterDiff: Int = metadata[IterDiff](s).map(_.diff).getOrElse(1)
     def iterDiff_=(diff: Int): Unit = metadata.add(s, IterDiff(diff))
+    def removeIterDiff: Unit = metadata.add(s,IterDiff(1))
 
     def segmentMapping: Map[Int,Int] = metadata[SegmentMapping](s).map(_.mapping).getOrElse(Map[Int,Int]())
     def segmentMapping_=(mapping: Map[Int,Int]): Unit = metadata.add(s, SegmentMapping(mapping))
+    def removeSegmentMapping: Unit = metadata.add(s,SegmentMapping(Map[Int,Int]()))
   }
 
   implicit class BankedMemoryOps(s: Sym[_]) {

--- a/src/spatial/transform/FlatteningTransformer.scala
+++ b/src/spatial/transform/FlatteningTransformer.scala
@@ -59,6 +59,7 @@ case class FlatteningTransformer(IR: State) extends MutateTransformer with Accel
         ctrl.bodies.foreach{body => 
           body.blocks.foreach{case (_,block) => 
             val block2 = f(block)
+            block.stms.foreach(visit)
             register(block -> block2)
           }
         }

--- a/src/spatial/transform/unrolling/MemReduceUnrolling.scala
+++ b/src/spatial/transform/unrolling/MemReduceUnrolling.scala
@@ -17,12 +17,25 @@ trait MemReduceUnrolling extends ReduceUnrolling {
       implicit val C: LocalMem[a,c] = op.C
       val accum2 = accumHack(accum.asInstanceOf[c[a]], loadAcc)
 
-      unrollMemReduce[a,c](lhs,f(en),f(cchainMap),f(cchainRed),accum2,f(zero),fold,func,loadRes,loadAcc,reduce,storeAcc,itersMap,itersRed)
+      if (cchainMap.willFullyUnroll && cchainRed.willFullyUnroll) {
+        // fullyUnrollMemReduceAndMap[a,c](lhs,f(en),f(cchainMap),f(cchainRed),accum2,f(zero),fold,func,loadRes,loadAcc,reduce,storeAcc,itersMap,itersRed)
+        fullyUnrollMemReduce[a,c](lhs,f(en),f(cchainMap),f(cchainRed),accum2,f(zero),fold,func,loadRes,loadAcc,reduce,storeAcc,itersMap,itersRed) 
+      }
+      else if (cchainMap.willFullyUnroll) {
+        // fullyUnrollMemReduceMap[a,c](lhs,f(en),f(cchainMap),f(cchainRed),accum2,f(zero),fold,func,loadRes,loadAcc,reduce,storeAcc,itersMap,itersRed) 
+        fullyUnrollMemReduce[a,c](lhs,f(en),f(cchainMap),f(cchainRed),accum2,f(zero),fold,func,loadRes,loadAcc,reduce,storeAcc,itersMap,itersRed) 
+      }
+      else if (cchainRed.willFullyUnroll) {
+        fullyUnrollMemReduce[a,c](lhs,f(en),f(cchainMap),f(cchainRed),accum2,f(zero),fold,func,loadRes,loadAcc,reduce,storeAcc,itersMap,itersRed) 
+      }
+      else {
+        partiallyUnrollMemReduce[a,c](lhs,f(en),f(cchainMap),f(cchainRed),accum2,f(zero),fold,func,loadRes,loadAcc,reduce,storeAcc,itersMap,itersRed)
+      }
 
     case _ => super.unrollCtrl(lhs, rhs)
   }
 
-  def unrollMemReduce[A,C[T]](
+  def fullyUnrollMemReduce[A,C[T]](
     lhs:       Sym[_],                // Original pipe symbol
     ens:       Set[Bit],              // Enables
     cchainMap: CounterChain,          // Map counterchain
@@ -41,11 +54,9 @@ trait MemReduceUnrolling extends ReduceUnrolling {
     logs(s"Unrolling accum-fold $lhs -> $accum")
 
     val mapLanes = PartialUnroller(s"${lhs}_map", cchainMap, itersMap, isInnerLoop = false)
-    val reduceLanes = PartialUnroller(s"${lhs}_red", cchainRed, itersRed, true)
+    val redLanes = FullUnroller(s"${lhs}_red", cchainRed, itersRed, true)
     val isMap2   = mapLanes.indices
-    val isRed2   = reduceLanes.indices
     val mvs      = mapLanes.indexValids
-    val rvs      = reduceLanes.indexValids
     val start    = cchainMap.counters.map(_.start.asInstanceOf[I32])
     val redType  = reduce.result.reduceType
     val intermed = func.result
@@ -55,11 +66,6 @@ trait MemReduceUnrolling extends ReduceUnrolling {
       logs(s"    Lane #$p")
       itersMap.foreach{i => logs(s"    $i -> ${f(i)}") }
     }
-    logs(s"  Reduction iterators: $isRed2")
-    reduceLanes.foreach{p =>
-      logs(s"    Lane #$p")
-      itersRed.foreach{i => logs(s"    $i -> ${f(i)}") }
-    }
 
     val blk = stageLambda1(accum){
       logs(s"[Accum-fold $lhs] Unrolling map")
@@ -68,88 +74,20 @@ trait MemReduceUnrolling extends ReduceUnrolling {
 
       val mvalids = () => mapLanes.valids.map{_.andTree}
 
-      if (cchainRed.isUnit) {
-        logs(s"[Accum-fold $lhs] Unrolling unit pipe reduction")
-        reduceLanes.foreach{p =>
-          logs(s"Lane #$p")
-          itersRed.foreach{i => logs(s"  $i -> ${f(i)}") }
-        }
-
-        stage(UnitPipe(enables ++ ens, stageBlock{
-          val values = inReduce(redType,true){
-            mapLanes.map{_ =>
-              reduceLanes.inLane(0){ loadRes.inline() }
-            }
-          }
-          val foldValue = if (fold) Some( loadAcc.inline() ) else None
-          unrollReduceAccumulate[A,C](accum, values, mvalids(), ident, foldValue, reduce, loadAcc, storeAcc, isMap2.map(_.head), start, isInner = false)
-          void
-        }))
+      logs(s"[Accum-fold $lhs] Unrolling unit pipe reduction")
+      redLanes.foreach{p =>
+        logs(s"Lane #$p")
+        itersRed.foreach{i => logs(s"  $i -> ${f(i)}") }
       }
-      else {
-        logs(s"[Accum-fold $lhs] Unrolling pipe-reduce reduction")
 
-        val rBlk = stageBlock{
-          logs(s"[Accum-fold $lhs] Unrolling map loads")
-          //logs(c"  memories: $mems")
-
-          val values: Seq[Seq[A]] = inReduce(redType,false){
-            mapLanes.map{i =>
-              register(intermed -> mems(i))
-              unroll(loadRes, reduceLanes)
-            }
-          }
-
-          logs(s"[Accum-fold $lhs] Unrolling accum loads")
-          val accValues = inReduce(redType,false){
-            register(loadAcc.input -> accum)
-            unroll(loadAcc, reduceLanes)
-          }
-
-          logs(s"[Accum-fold $lhs] Unrolling reduction trees and cycles")
-          val results = reduceLanes.map{p =>
-            val laneValid = reduceLanes.valids(p).andTree
-
-            logs(s"Lane #$p:")
-            val inputs = values.map(_.apply(p)) // The pth value of each vector load
-            val valids = mvalids().map{mvalid => mvalid & laneValid }
-
-            val accValue = accValues(p)
-
-            val result = inReduce(redType,true){
-              val treeResult = unrollReduceTree(inputs, valids, ident, reduce.toFunction2)
-              val isFirst = isMap2.map(_.head).zip(start).map{case (i,st) => i === st }.andTree
-
-              if (fold || spatialConfig.ignoreParEdgeCases) {
-                // FOLD: On first iteration, use value of accumulator value rather than zero
-                //val accumOrFirst = math_mux(isFirst, init, accValue)
-                reduce.reapply(treeResult, accValue)
-              }
-              else {
-                // REDUCE: On first iteration, store result of tree, do not include value from accum
-                val res2   = reduce.reapply(treeResult, accValue)
-                val select = mux(isFirst, treeResult, res2)
-                box(select).reduceType = redType
-                select
-              }
-            }
-
-            register(reduce.result -> result)  // Lane-specific substitution
-            result
-          }
-
-          logs(s"[Accum-fold $lhs] Unrolling accumulator store")
-          // Use a default substitution for the reduction result to satisfy the block scheduler
-          inReduce(redType,false){ isolateSubst(){
-            register(storeAcc.inputA -> accum)
-            register(reduce.result -> results.head)
-            unroll(storeAcc, reduceLanes)
-          }}
-          void
-        }
-
-        stage(UnrolledForeach(Set.empty, cchainRed, rBlk, isRed2, rvs))
+      stageWithFlow(UnitPipe(enables ++ ens, stageBlock{
+        unrollMemReduceAccumulate(lhs, accum, ident, intermed, fold, reduce, loadRes, loadAcc, storeAcc, redType, itersMap, itersRed, start, mapLanes, redLanes)
+        // val foldValue = if (fold) Some( loadAcc.inline() ) else None
+        // unrollReduceAccumulate[A,C](accum, values, mvalids(), ident, foldValue, reduce, loadAcc, storeAcc, isMap2.map(_.head), start, redLanes, isInner = false)
+      })){lhs2 =>
+        transferData(lhs,lhs2)
       }
+    
     }
 
     val lhs2 = stageWithFlow(UnrolledReduce(enables ++ ens, cchainMap, blk, isMap2, mvs)){lhs2 =>
@@ -159,6 +97,147 @@ trait MemReduceUnrolling extends ReduceUnrolling {
 
     logs(s"[Accum-fold] Created reduce ${stm(lhs2)}")
     lhs2
+  }
+
+  def partiallyUnrollMemReduce[A,C[T]](
+    lhs:       Sym[_],                // Original pipe symbol
+    ens:       Set[Bit],              // Enables
+    cchainMap: CounterChain,          // Map counterchain
+    cchainRed: CounterChain,          // Reduction counterchain
+    accum:     C[A],                  // Accumulator (external)
+    ident:     Option[A],             // Optional identity value for reduction
+    fold:      Boolean,               // Optional value to fold with reduction
+    func:      Block[C[A]],           // Map function
+    loadRes:   Lambda1[C[A],A],       // Load function for intermediate values
+    loadAcc:   Lambda1[C[A],A],       // Load function for accumulator
+    reduce:    Lambda2[A,A,A],        // Reduction function
+    storeAcc:  Lambda2[C[A],A,Void],  // Store function for accumulator
+    itersMap:  Seq[I32],              // Bound iterators for map loop
+    itersRed:  Seq[I32]               // Bound iterators for reduce loop
+  )(implicit A: Bits[A], C: LocalMem[A,C], ctx: SrcCtx): Void = {
+    logs(s"Unrolling accum-fold $lhs -> $accum")
+
+    val mapLanes = PartialUnroller(s"${lhs}_map", cchainMap, itersMap, isInnerLoop = false)
+    val redLanes = PartialUnroller(s"${lhs}_red", cchainRed, itersRed, true)
+    val isMap2   = mapLanes.indices
+    val isRed2   = redLanes.indices
+    val mvs      = mapLanes.indexValids
+    val rvs      = redLanes.indexValids
+    val start    = cchainMap.counters.map(_.start.asInstanceOf[I32])
+    val redType  = reduce.result.reduceType
+    val intermed = func.result
+
+    logs(s"  Map iterators: $isMap2")
+    mapLanes.foreach{p =>
+      logs(s"    Lane #$p")
+      itersMap.foreach{i => logs(s"    $i -> ${f(i)}") }
+    }
+
+    logs(s"  Reduction iterators: $isRed2")
+    redLanes.foreach{p =>
+      logs(s"    Lane #$p")
+      itersRed.foreach{i => logs(s"    $i -> ${f(i)}") }
+    }
+
+    val blk = stageLambda1(accum){
+      logs(s"[Accum-fold $lhs] Unrolling map")
+      unrollWithoutResult(func, mapLanes)
+
+      logs(s"[Accum-fold $lhs] Unrolling pipe-reduce reduction")
+
+      val rBlk = stageBlock{
+        logs(s"[Accum-fold $lhs] Unrolling map loads")
+        unrollMemReduceAccumulate(lhs, accum, ident, intermed, fold, reduce, loadRes, loadAcc, storeAcc, redType, itersMap, itersRed, start, mapLanes, redLanes)
+      }
+
+      stage(UnrolledForeach(Set.empty, cchainRed, rBlk, isRed2, rvs))
+    }
+
+    val lhs2 = stageWithFlow(UnrolledReduce(enables ++ ens, cchainMap, blk, isMap2, mvs)){lhs2 =>
+      transferData(lhs,lhs2)
+    }
+    //accumulatesTo(lhs2) = accum
+
+    logs(s"[Accum-fold] Created reduce ${stm(lhs2)}")
+    lhs2
+  }
+
+
+  def unrollMemReduceAccumulate[A:Bits,C[T]](
+    lhs: Sym[_],
+    accum:  C[A],                 // Accumulator
+    ident:  Option[A],            // Optional identity value
+    intermed: Sym[_],
+    fold:   Boolean,            // Optional fold value
+    reduce: Lambda2[A,A,A],       // Reduction function
+    loadRes:   Lambda1[C[A],A],      // Load function from accumulator
+    loadAcc:   Lambda1[C[A],A],      // Load function from accumulator
+    storeAcc:  Lambda2[C[A],A,Void], // Store function to accumulator
+    redType: Option[ReduceFunction],
+    itersMap:  Seq[I32],             // Iterators for entire reduction (used to determine when to reset)
+    itersRed:  Seq[I32],             // Iterators for entire reduction (used to determine when to reset)
+    start:  Seq[I32],             // Start for each iterator
+    mapLanes: PartialUnroller,
+    redLanes: Unroller
+  )(implicit ctx: SrcCtx): Void = {
+    val mems = mapLanes.map{_ => memories((intermed,0)) } // TODO: Just use the first duplicate always?
+    val mvalids = () => mapLanes.valids.map{_.andTree}
+    val isMap2   = mapLanes.indices
+
+    val values: Seq[Seq[A]] = inReduce(redType,false){
+      mapLanes.map{i =>
+        register(intermed -> mems(i))
+        unroll(loadRes, redLanes)
+      }
+    }
+
+    logs(s"[Accum-fold $lhs] Unrolling accum loads")
+    val accValues = inReduce(redType,false){
+      register(loadAcc.input -> accum)
+      unroll(loadAcc, redLanes)
+    }
+
+    logs(s"[Accum-fold $lhs] Unrolling reduction trees and cycles")
+    val results = redLanes.map{p =>
+      val laneValid = redLanes.valids(p).andTree
+
+      logs(s"Lane #$p:")
+      val inputs = values.map(_.apply(p)) // The pth value of each vector load
+      val valids = mvalids().map{mvalid => mvalid & laneValid }
+
+      val accValue = accValues(p)
+
+      val result = inReduce(redType,true){
+        val treeResult = unrollReduceTree(inputs, valids, ident, reduce.toFunction2)
+        val isFirst = isMap2.map(_.head).zip(start).map{case (i,st) => i === st }.andTree
+
+        if (fold || spatialConfig.ignoreParEdgeCases) {
+          // FOLD: On first iteration, use value of accumulator value rather than zero
+          //val accumOrFirst = math_mux(isFirst, init, accValue)
+          reduce.reapply(treeResult, accValue)
+        }
+        else {
+          // REDUCE: On first iteration, store result of tree, do not include value from accum
+          val res2   = reduce.reapply(treeResult, accValue)
+          val select = mux(isFirst, treeResult, res2)
+          box(select).reduceType = redType
+          select
+        }
+      }
+
+      register(reduce.result -> result)  // Lane-specific substitution
+      result
+    }
+
+    logs(s"[Accum-fold $lhs] Unrolling accumulator store")
+    // Use a default substitution for the reduction result to satisfy the block scheduler
+    inReduce(redType,false){ isolateSubst(){
+      register(storeAcc.inputA -> accum)
+      register(reduce.result -> results.head)
+      unroll(storeAcc, redLanes)
+    }}
+
+    void
   }
 
 }

--- a/test/spatial/tests/feature/sparse/PageRank.scala
+++ b/test/spatial/tests/feature/sparse/PageRank.scala
@@ -68,7 +68,7 @@
      setMem(OCedgeLens, edgeLens)
      setMem(OCedgeIds, edgeIds)
 
-     Accel {
+     Accel { 
        Sequential.Foreach(iters by 1) { iter =>
          // Step through each tile
          Foreach(NP by tileSize par tile_par) { page =>
@@ -118,7 +118,7 @@
              }{_+_}
 
              // Write new rank
-             local_pages(local_page) = pagerank * damp + (1.to[X] - damp)
+             local_pages(local_page) = pagerank * damp + (1.to[X] - damp) / NP.value.to[X]
            }
            OCpages(page :: page + pages_left par par_store) store local_pages
          }
@@ -145,7 +145,7 @@
          val these_counts = these_edges.map { j => edgeLens(j) }
          val pr = these_pages.zip(these_counts){(p, c) => p / c.to[X] }.sum
          // println("new pr for " + i + " is " + pr)
-         gold(i) = pr * dampIN + (1.to[X] - dampIN)
+         gold(i) = pr * dampIN + (1.to[X] - dampIN) / rows.to[X]
        }
      }
 

--- a/test/spatial/tests/feature/unrolling/UnrollingTest.scala
+++ b/test/spatial/tests/feature/unrolling/UnrollingTest.scala
@@ -31,59 +31,58 @@ import spatial.dsl._
   def main(args: Array[String]): Unit = {
     type T = Int64
 
-    val dram1 = DRAM[T](8)
-    val dram2 = DRAM[T](8)
-    val dram3 = DRAM[T](8)
-    val dram4 = DRAM[T](8)
-    val dram5 = DRAM[T](8)
-    val tile = 2
+    val tile = 8
+    val memsize = 64
+    val mapIters = 4
 
-    setMem(dram1, Array.tabulate[T](8){i => i.to[T]})
+    val dram1 = DRAM[T](memsize)
+    val dram2 = DRAM[T](memsize)
+    val dram3 = DRAM[T](memsize)
+    val dram4 = DRAM[T](memsize)
+    val dram5 = DRAM[T](memsize)
+
+    setMem(dram1, Array.tabulate[T](memsize){i => i.to[T]})
 
     Accel {
-      val x = SRAM[T](8)
+      val x = SRAM[T](memsize)
       x load dram1
-      // // unroll map and reduce
-      // val x1 = SRAM[T](tile,1)
-      // Foreach(8 by tile){i => 
-      //   x1 load dram1(i::i+tile)
-      //   MemReduce(x1(0::tile par tile))(2 by 1 par 2){j => x1}{_+_}
-      //   dram2(i::i+tile) store x1
-      // }
+      // unroll map and reduce
+      val x1 = SRAM[T](tile)
+      'UNROLLmr.Foreach(memsize by tile){i => 
+        MemReduce(x1(0::tile par tile))(mapIters by 1 par mapIters){j => x(i::i+tile)}{_+_}
+        dram2(i::i+tile) store x1
+      }
 
       // unroll reduce only
       val x2 = SRAM[T](tile)
-      Foreach(8 by tile){i => 
-        x2 load dram1(i::i+tile)
-        MemReduce(x2(0::tile par tile))(2 by 1){j => x(i::i+tile)}{_+_}
+      'UNROLLr.Foreach(memsize by tile){i => 
+        MemReduce(x2(0::tile par tile))(mapIters by 1){j => x(i::i+tile)}{_+_}
         dram3(i::i+tile) store x2
       }
 
-      // // unroll reduce only
-      // val x3 = SRAM[T](tile,1)
-      // Foreach(8 by tile){i => 
-      //   x3 load dram1(i::i+tile)
-      //   MemReduce(x3)(2 by 1 par 2){j => x3}{_+_}
-      //   dram4(i::i+tile) store x3
-      // }
+      // unroll map only
+      val x3 = SRAM[T](tile)
+      'UNROLLm.Foreach(memsize by tile){i => 
+        MemReduce(x3)(mapIters by 1 par mapIters){j => x(i::i+tile)}{_+_}
+        dram4(i::i+tile) store x3
+      }
 
       // no unrolling
       val x4 = SRAM[T](tile)
-      Foreach(8 by tile){i => 
-        x4 load dram1(i::i+tile)
-        MemReduce(x4)(2 by 1){j => x(i::i+tile)}{_+_}
-        dram4(i::i+tile) store x4
+      'UNROLLnone.Foreach(memsize by tile){i => 
+        MemReduce(x4)(mapIters by 1){j => x(i::i+tile)}{_+_}
+        dram5(i::i+tile) store x4
       }
 
 
     }
 
-    val gold = Array.tabulate[T](8){i => 2*i.to[T]}
-    printArray(gold, "Dumb Load SRC")
-    printArray(getMem(dram2), "Dumb Load (unroll both) DST1")
-    printArray(getMem(dram3), "Dumb Load (unroll reduce) DST1")
-    printArray(getMem(dram4), "Dumb Load (unroll map) DST1")
-    printArray(getMem(dram5), "Dumb Load (no unroll) DST1")
+    val gold = Array.tabulate[T](memsize){i => mapIters*i.to[T]}
+    printArray(gold, "gold")
+    printArray(getMem(dram2), r"unroll both. Pass: ${getMem(dram2) == gold}")
+    printArray(getMem(dram3), r"unroll reduce. Pass: ${getMem(dram3) == gold}")
+    printArray(getMem(dram4), r"unroll map. Pass: ${getMem(dram4) == gold}")
+    printArray(getMem(dram5), r"no unroll. Pass: ${getMem(dram5) == gold}")
     assert(gold == getMem(dram2))
     assert(gold == getMem(dram3))
     assert(gold == getMem(dram4))

--- a/test/spatial/tests/feature/unrolling/UnrollingTest.scala
+++ b/test/spatial/tests/feature/unrolling/UnrollingTest.scala
@@ -26,6 +26,71 @@ import spatial.dsl._
 
 }
 
+@spatial class MemReduceToUnitPipe extends SpatialTest {
+
+  def main(args: Array[String]): Unit = {
+    type T = Int64
+
+    val dram1 = DRAM[T](8)
+    val dram2 = DRAM[T](8)
+    val dram3 = DRAM[T](8)
+    val dram4 = DRAM[T](8)
+    val dram5 = DRAM[T](8)
+    val tile = 2
+
+    setMem(dram1, Array.tabulate[T](8){i => i.to[T]})
+
+    Accel {
+      val x = SRAM[T](8)
+      x load dram1
+      // // unroll map and reduce
+      // val x1 = SRAM[T](tile,1)
+      // Foreach(8 by tile){i => 
+      //   x1 load dram1(i::i+tile)
+      //   MemReduce(x1(0::tile par tile))(2 by 1 par 2){j => x1}{_+_}
+      //   dram2(i::i+tile) store x1
+      // }
+
+      // unroll reduce only
+      val x2 = SRAM[T](tile)
+      Foreach(8 by tile){i => 
+        x2 load dram1(i::i+tile)
+        MemReduce(x2(0::tile par tile))(2 by 1){j => x(i::i+tile)}{_+_}
+        dram3(i::i+tile) store x2
+      }
+
+      // // unroll reduce only
+      // val x3 = SRAM[T](tile,1)
+      // Foreach(8 by tile){i => 
+      //   x3 load dram1(i::i+tile)
+      //   MemReduce(x3)(2 by 1 par 2){j => x3}{_+_}
+      //   dram4(i::i+tile) store x3
+      // }
+
+      // no unrolling
+      val x4 = SRAM[T](tile)
+      Foreach(8 by tile){i => 
+        x4 load dram1(i::i+tile)
+        MemReduce(x4)(2 by 1){j => x(i::i+tile)}{_+_}
+        dram4(i::i+tile) store x4
+      }
+
+
+    }
+
+    val gold = Array.tabulate[T](8){i => 2*i.to[T]}
+    printArray(gold, "Dumb Load SRC")
+    printArray(getMem(dram2), "Dumb Load (unroll both) DST1")
+    printArray(getMem(dram3), "Dumb Load (unroll reduce) DST1")
+    printArray(getMem(dram4), "Dumb Load (unroll map) DST1")
+    printArray(getMem(dram5), "Dumb Load (no unroll) DST1")
+    assert(gold == getMem(dram2))
+    assert(gold == getMem(dram3))
+    assert(gold == getMem(dram4))
+    assert(gold == getMem(dram5))
+  }
+}
+
 
 @spatial class SwitchCondReuse extends SpatialTest {
   override def runtimeArgs: Args = "1"


### PR DESCRIPTION
Fully parallelized map and/or reduce functions in `MemReduce` used to not fully unroll properly.  It used to check if the reduce counter `isUnit`, and if so, it called into the `Reduce` unroller to try to do the full unrolling but there was some bad stuff happening there that caused it to crash.

I basically just rewrote the memreduce unroller to look similar to the others