### PR TITLE
Improved error messages thrown while reading a not existing files_list

### DIFF
--- a/argon/src/argon/codegen/FileDependencies.scala
+++ b/argon/src/argon/codegen/FileDependencies.scala
@@ -1,13 +1,20 @@
 package argon
 package codegen
 
+import java.io.FileNotFoundException
+
 import utils.io.files
 
 trait FileDependencies extends Codegen {
   var dependencies: List[CodegenDep] = Nil
 
   lazy val files_list: Seq[String] = {
-    io.Source.fromURL(getClass.getResource("/files_list")).mkString("").split("\n")
+    val url = getClass.getResource("/files_list")
+    if (url == null)
+      throw new FileNotFoundException(
+        "File \"files_list\" is not found, please run bin/update_resources.sh before launching a SpatialApp.")
+
+    io.Source.fromURL(url).mkString("").split("\n")
   }
 
   sealed trait CodegenDep {


### PR DESCRIPTION
Hello, this is a minor improvement related to issue #201.

Instead of showing NPE when `files_list` doesn't exist, a `FileNotFoundException` will be thrown that indicates `./bin/update_resources.sh` should be executed beforehand. 