### PR TITLE
Lockstep refactor

### DIFF
--- a/poly/src/poly/ConstraintMatrix.scala
+++ b/poly/src/poly/ConstraintMatrix.scala
@@ -12,10 +12,12 @@ case class ConstraintMatrix[K](rows: Set[SparseConstraint[K]], hasDomain: Boolea
     keys.map{k => isl.domain(k) }.fold(ConstraintMatrix.empty){_::_}
   }
 
-  def replaceKeys(keySwap: Map[K,K]): ConstraintMatrix[K] = {
+  def replaceKeys(keySwap: Map[K,(K,Int)]): ConstraintMatrix[K] = {
     val rows2 = rows.map{r => 
-      val cols2 = r.cols.map{case (k,v) => (keySwap.getOrElse(k,k) -> v)}
-      SparseConstraint[K](cols2, r.c, r.tp)
+      val cols2 = r.cols.map{case (k,v) => (keySwap.getOrElse(k,(k,0))._1 -> v)}
+      // TODO: Not sure if this is the correct way to include offset adjustment for a constraint
+      val offset = r.cols.collect{case (k,_) if (keySwap.contains(k)) => keySwap(k)._2}.sum
+      SparseConstraint[K](cols2, r.c + offset, r.tp)
     }
     ConstraintMatrix[K](rows2, hasDomain)
   }

--- a/poly/src/poly/SparseMatrix.scala
+++ b/poly/src/poly/SparseMatrix.scala
@@ -4,10 +4,11 @@ import utils.implicits.collections._
 
 case class SparseMatrix[K](rows: Seq[SparseVector[K]]) {
   def keys: Set[K] = rows.map(_.cols.keySet).fold(Set.empty)(_++_)
-  def replaceKeys(keySwap: Map[K,K]): SparseMatrix[K] = {
+  def replaceKeys(keySwap: Map[K,(K,Int)]): SparseMatrix[K] = {
     val rows2 = rows.map{r => 
-      val cols2 = r.cols.map{case (k,v) => (keySwap.getOrElse(k,k) -> v)}
-      SparseVector[K](cols2, r.c, r.allIters)
+      val cols2 = r.cols.map{case (k,v) => (keySwap.getOrElse(k,(k,0))._1 -> v)}
+      val offset = r.cols.collect{case (k,_) if (keySwap.contains(k)) => keySwap(k)._2}.sum
+      SparseVector[K](cols2, r.c + offset, r.allIters)
     }
     SparseMatrix[K](rows2)
   }

--- a/src/spatial/Spatial.scala
+++ b/src/spatial/Spatial.scala
@@ -101,6 +101,7 @@ trait Spatial extends Compiler with ParamLoader {
     lazy val transientCleanup      = TransientCleanup(state)
     lazy val unrollTransformer     = UnrollingTransformer(state)
     lazy val rewriteTransformer    = RewriteTransformer(state)
+    lazy val laneStaticTransformer = LaneStaticTransformer(state)
     lazy val flatteningTransformer = FlatteningTransformer(state)
     lazy val bindingTransformer    = BindingTransformer(state)
     lazy val retiming              = RetimingTransformer(state)
@@ -144,6 +145,7 @@ trait Spatial extends Compiler with ParamLoader {
         switchTransformer   ==> printer ==> transformerChecks ==>
         switchOptimizer     ==> printer ==> transformerChecks ==>
         memoryDealiasing    ==> printer ==> transformerChecks ==>
+        ((!spatialConfig.vecInnerLoop) ? laneStaticTransformer)   ==>  printer ==>
         /** Control insertion */
         pipeInserter        ==> printer ==> transformerChecks ==>
         /** CSE on regs */

--- a/src/spatial/lang/control/ForeachClass.scala
+++ b/src/spatial/lang/control/ForeachClass.scala
@@ -26,7 +26,7 @@ class ForeachClass(opt: CtrlOpt) {
   @rig def apply(ctrs: Seq[Counter[I32]])(func: Seq[I32] => Any): Void = {
     val iters  = ctrs.map{_ => boundVar[I32] }
     val cchain = CounterChain(ctrs)
-    cchain.counters.zip(iters).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq(0)) }
+    cchain.counters.zip(iters).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq.tabulate(ctr.ctrParOr1){i => i}) }
     stageWithFlow(OpForeach(Set.empty, cchain, stageBlock{ func(iters); void }, iters, opt.stopWhen)){pipe =>
       opt.set(pipe)
     }

--- a/src/spatial/lang/control/MemReduceClass.scala
+++ b/src/spatial/lang/control/MemReduceClass.scala
@@ -58,8 +58,8 @@ protected class MemReduceAccum[A,C[T]](
 
     val itersMap = List.fill(domain.length){ boundVar[I32] }
     val itersRed = List.fill(acc.sparseRank.length){ boundVar[I32] }
-    domain.zip(itersMap).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq(0)) }
-    ctrsRed.zip(itersRed).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq(0)) }
+    domain.zip(itersMap).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq.tabulate(ctr.ctrParOr1){i => i}) }
+    ctrsRed.zip(itersRed).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq.tabulate(ctr.ctrParOr1){i => i}) }
 
     //logs(s"  itersMap: $itersMap")
     //logs(s"  itersRed: $itersRed")

--- a/src/spatial/lang/control/ReduceClass.scala
+++ b/src/spatial/lang/control/ReduceClass.scala
@@ -41,7 +41,7 @@ protected class ReduceAccum[A](accum: Option[Reg[A]], ident: Option[A], init: Op
     val lA = boundVar[A]
     val rA = boundVar[A]
     val iters  = List.fill(domain.length){ boundVar[I32] }
-    domain.zip(iters).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq(0)) }
+    domain.zip(iters).foreach{case (ctr, i) => i.counter = IndexCounterInfo(ctr, Seq.tabulate(ctr.ctrParOr1){i => i}) }
     val mapBlk = stageBlock{ map(iters) }
     val ldBlk  = stageLambda1(acc){ acc.value }
     val redBlk = stageLambda2(lA,rA){ reduce(lA,rA) }

--- a/src/spatial/metadata/access/AccessPatterns.scala
+++ b/src/spatial/metadata/access/AccessPatterns.scala
@@ -234,8 +234,9 @@ case class AddressPattern(
       // Create new rand if necessary.  It depends on the iterators inside "others" as well as (TODO?) any iterators from a more-outer uid lane
       val rand: Seq[(Idx, Int)] = if (others.nonEmpty) Seq((boundVar[I32],1)) else Nil
 
-      val xs_all: Seq[Idx] = affine_comps.map(_._2) ++ rs.map(_._1) ++ starts ++ rand.map(_._1)
-      val as_all: Seq[Int] = affine_comps.map(_._1.b) ++ rs.map(_._2) ++ starts.indices.map{_ => 1} ++ rand.map(_._2)
+      // Updated lockstepness check takes care of starts
+      val xs_all: Seq[Idx] = affine_comps.map(_._2) ++ rs.map(_._1) ++ /*starts ++*/ rand.map(_._1)
+      val as_all: Seq[Int] = affine_comps.map(_._1.b) ++ rs.map(_._2) ++ /*starts.indices.map{_ => 1} ++*/ rand.map(_._2)
       if (rand.isEmpty) Some( SparseVector(xs_all.zip(as_all).toMap, bx.b, allIters) )
       else Some( SparseVector(xs_all.zip(as_all).toMap, bx.b, allIters ++ Map[Idx, Seq[Idx]](rand.head._1 -> others.map(_._2).toSeq)) )
     }

--- a/src/spatial/metadata/access/AffineData.scala
+++ b/src/spatial/metadata/access/AffineData.scala
@@ -28,8 +28,8 @@ case class AccessMatrix(
 ) {
   def keys: Set[Idx] = matrix.keys
   @stateful def parent: Ctrl = access.parent
-  def randomizeKeys(keySwap: Map[Idx,Idx]): AccessMatrix = {
-    keySwap.foreach{case (old, swp) => swp.domain = old.domain.replaceKeys(keySwap)}
+  def substituteKeys(keySwap: Map[Idx,(Idx,Int)]): AccessMatrix = {
+    keySwap.foreach{case (old, (swp,_)) => swp.domain = old.domain.replaceKeys(keySwap)}
     val matrix2 = matrix.replaceKeys(keySwap) 
     AccessMatrix(access, matrix2, unroll)
   }

--- a/src/spatial/metadata/access/package.scala
+++ b/src/spatial/metadata/access/package.scala
@@ -227,32 +227,22 @@ package object access {
     pomMask.zipWithIndex.collect{case (take,i) if (i < position || take) => fullUID(i)}
   }
 
-  /** Checks the iters in accesses a and b for those which can dephase due to controllers not running in lockstep.  Returns a Set of 
-    * iter - Seq[Int] pair that identify the unroll ID addressing that identifies where it dephases from. 
+  /** Checks if iterators in a and b are relatively dephased or not */
+  @stateful def divergedIters(a: AccessMatrix, b: AccessMatrix, mem: Sym[_]): Set[Idx] = {
+    val dephaseA = dephasingIters(a, mem)
+    val dephaseB = dephasingIters(b, mem)
+    accessIterators(a.access, mem).collect{case i if (!dephaseA.map(_._1._1).toSeq.contains(i) || !dephaseB.map(_._1._1).toSeq.contains(i)) => i}.toSet
+  }
+
+  /** Checks the iters in access a for those which can dephase due to controllers not being synchronized with base uid.  
+    * Returns a mapping between iter, uid to the ofs to include for that iter.  If the offset is None, assume total dephasing 
     *
     * We can use this info to create replacement rules for each iter in each access that may conflict due to lockstep dephasing
     */
-  @stateful def dephasingIters(a: AccessMatrix, b: AccessMatrix, mem: Sym[_]): Set[(Idx,Seq[Int])] = {
+  @stateful def dephasingIters(a: AccessMatrix, mem: Sym[_]): Map[(Idx,Seq[Int]),Option[Int]] = {
     val aIters: Seq[Idx] = accessIterators(a.access, mem)
-    val bIters: Seq[Idx] = accessIterators(b.access, mem)
-    // Figure out the uid position where iterators start to diverge (minimum of first iterator whose parent will unroll as POM and first uid in a to differ from uid in b)
-    val pomForkLayer = aIters.zipWithIndex.collectFirst{case (it,i) if it.parent.s.get.willUnrollAsPOM => i} 
-    // TODO: uidForkLayer should actually find first divergence and grab mark fork at LAST iterator that is part of this forked cchain
-    val uidForkLayer = a.unroll.zip(b.unroll).zipWithIndex.collectFirst{case ((u0,u1),i) if (u0 != u1) => i}
-    val forkLayer = if (pomForkLayer.isDefined && uidForkLayer.isDefined) Some(pomForkLayer.get min uidForkLayer.get) 
-                    else if (pomForkLayer.isDefined || uidForkLayer.isDefined) Some(pomForkLayer.getOrElse(0) + uidForkLayer.getOrElse(0))
-                    else None
-    // For any iters a and b have in common, check if the iterator's owner's parent has children running in lockstep. 
-    //   return false if we find at least one who is not in lockstep
-    if (forkLayer.isDefined && aIters(forkLayer.get).parent.s.get.isOuterControl) {
-      val forkNode = aIters(forkLayer.get).parent.s.get
-
-      val dephaseStart = if (pomForkLayer == forkLayer) pomForkLayer.get - 1 else uidForkLayer.get // minus 1 for pom because iterator exactly at fork is dephased
-      val mustClone = !forkNode.isLockstepAcross(aIters, Some(a.access), Some(forkNode.toCtrl))
-      val mapping:Set[(Idx,Seq[Int])] = if (mustClone) aIters.zipWithIndex.collect{case (x,i) if i > dephaseStart => (x, getDephasedUID(aIters, a.unroll, i))}.toSet
-                                        else Set()
-      mapping
-    } else Set()    
+    val ofsRules = if (aIters.nonEmpty) aIters.head.parent.s.get.iterLockstepInfo(aIters, a.unroll) else Map[Idx,Int]()
+    aIters.map{i => ((i,a.unroll) -> ofsRules.get(i))}.toMap
   }
 
 

--- a/src/spatial/metadata/control/package.scala
+++ b/src/spatial/metadata/control/package.scala
@@ -435,8 +435,14 @@ package object control {
     /** Computes the ofs between iter from uid to baseline if applicable, due to iter's cchain having a start value that depends on uid divergence */
     @stateful def iterOfs(iter: Idx, itersAbove: Seq[Seq[Idx]], uid: Seq[Seq[Int]], base: Seq[Seq[Int]]): Int = {
       val startSym = iter.ctrStart
-      // dbgs(s"want iterOfs of $iter for $itersAbove at $uid relative $base")
-      0
+      startSym match {
+        case Op(LaneStatic(dep, elems)) => 
+          val position = itersAbove.flatten.indexOf(dep)
+          val upper = elems(uid.flatten.apply(position))
+          val lower = elems(base.flatten.apply(position))
+          upper - lower
+        case _ => 0
+      }
     }
 
     /** Returns true if the subtree rooted at ctrl run for the same number of cycles (i.e. iterations) regardless of uid.

--- a/src/spatial/metadata/control/package.scala
+++ b/src/spatial/metadata/control/package.scala
@@ -1175,7 +1175,8 @@ package object control {
             val dist = getCoarseDistance(metapipe, anchor, a)
             dbgs(s"$a <-> $anchor # LCA: $metapipe, Dist: $dist")
 
-            if (group.exists{x => a == x._1 || a == x._2 }) a -> dist else a -> None
+            // As long as a is in the metapipeLCAs map, or is a reader that was unmapped because its LCA with writer is inner control, assign its dist
+            if (group.exists{x => a.isReader || a == x._1 || a == x._2 }) a -> dist else a -> None
           }
           val buffers = dists.filter{_._2.isDefined}.map(_._2.get)
           val minDist = buffers.minOrElse(0)

--- a/src/spatial/metadata/control/package.scala
+++ b/src/spatial/metadata/control/package.scala
@@ -449,7 +449,9 @@ package object control {
       * includeOuter flag identifies whether the outermost iterator of the cchain should be ignored or not
       */
     @stateful def synchronizedStart(forkedIters: Seq[Idx], includeOuter: Boolean): Boolean = {
-      cchainIsInvariant(forkedIters, includeOuter) && children.filter(_.s.get != s.get).forall(_.synchronizedStart(forkedIters, includeOuter = true))
+      val meSynch = cchainIsInvariant(forkedIters, includeOuter)
+      val childrenSynch = children.filter(_.s.get != s.get).forall(_.synchronizedStart(forkedIters, includeOuter = true))
+      meSynch && childrenSynch
     }
     /** Returns true if this counterchain is invariant with iterators above it that diverge */
     @stateful def cchainIsInvariant(forkedIters: Seq[Idx], includeOuter: Boolean): Boolean = {
@@ -906,7 +908,7 @@ package object control {
       import spatial.util.modeling._
       val deps = mutatingBounds(start) ++ mutatingBounds(end) ++ mutatingBounds(step)
       nIters match {
-        case Some(Expect(_)) => forkedIters.exists(deps.contains)
+        case Some(Expect(_)) => !forkedIters.exists(deps.contains)
         case _ => 
           val startFixed = start match {case Expect(_) => true; case x if x.isArgInRead => true; case _ => false}//case x if (relative.getOrElse(Ctrl.Host).ancestors.contains(x.parent)) => true; case _ => false}
           val stepFixed = step match {case Expect(_) => true; case x if x.isArgInRead => true; case _ => false}//case x if (relative.getOrElse(Ctrl.Host).ancestors.contains(x.parent)) => true; case _ => false}

--- a/src/spatial/node/LaneStatic.scala
+++ b/src/spatial/node/LaneStatic.scala
@@ -1,0 +1,16 @@
+package spatial.node
+
+import argon._
+import argon.node._
+import forge.tags._
+import spatial.lang._
+
+@op case class LaneStatic[A:Bits](iter: A, elems: Seq[scala.Int]) extends Primitive[A] {
+  override val isTransient: Boolean = true
+
+  @stateful def simplify[A:Bits](x: A, value: scala.Int): A = {
+    x.from(value)
+  }
+
+  @rig override def rewrite: A = if (elems.size == 1) simplify(iter, elems.head) else super.rewrite
+}

--- a/src/spatial/transform/BindingTransformer.scala
+++ b/src/spatial/transform/BindingTransformer.scala
@@ -44,7 +44,7 @@ case class BindingTransformer(IR: State) extends MutateTransformer with AccelTra
       val activeWrMems = c.nestedWrittenMems.toSet ++ c.nestedWrittenDRAMs.toSet
       val nextShouldNotBind = (Seq(c.toCtrl) ++ c.nestedChildren).exists(_.s.get.shouldNotBind) | (c.isSwitch && c.op.exists(_.R.isBits))
       val prevShouldNotBind = (Seq((lhs.children.apply(i))) ++ (lhs.children.apply(i)).nestedChildren).exists(_.s.get.shouldNotBind) | (lhs.children.apply(i).s.get.isSwitch && lhs.children.apply(i).s.get.op.exists(_.R.isBits))
-      val streamShouldNotBind = c.hasStreamAncestor && (activeMems.filter{mem => mem.isStreamOut || mem.isFIFO || mem.isMergeBuffer || mem.isFIFOReg || mem.isStreamIn}.nonEmpty)
+      val streamShouldNotBind = lhs.hasStreamAncestor && (activeMems.filter{mem => mem.isStreamOut || mem.isFIFO || mem.isMergeBuffer || mem.isFIFOReg || mem.isStreamIn}.nonEmpty)
       if (prevMems.intersect(activeMems).intersect(activeWrMems ++ prevWrMems ++ addressableMems).nonEmpty || nextShouldNotBind || prevShouldNotBind || streamShouldNotBind) {
         dbgs(s"Conflict between:")
         dbgs(s" - Prev rd/wr: $prevMems")

--- a/src/spatial/transform/LaneStaticTransformer.scala
+++ b/src/spatial/transform/LaneStaticTransformer.scala
@@ -1,0 +1,75 @@
+package spatial.transform
+
+import argon._
+import argon.node._
+import emul.ResidualGenerator._
+import argon.transform.MutateTransformer
+import spatial.metadata.bounds._
+import spatial.metadata.control._
+import spatial.metadata.memory._
+import spatial.metadata.types._
+import spatial.metadata.rewrites._
+import spatial.metadata.retiming._
+import spatial.metadata.math._
+import spatial.lang._
+import spatial.node._
+import spatial.util.spatialConfig
+import spatial.traversal.AccelTraversal
+import forge.tags._
+import emul.FixedPoint
+
+import utils.math.{isPow2,log2,gcd}
+import spatial.util.math._
+
+/** This transformer looks at the pre-unrolled, pre-pipe-insertion IR for situations where
+  * FixMod nodes will statically resolve only AFTER unrolling.  It replaces them with a LaneStatic
+  * node, which is transient, and therefore skips wrapping the original FixMod node in a unit pipe.
+  * This is also necessary for banking analysis lockstep/iter offset analysis
+  */
+case class LaneStaticTransformer(IR: State) extends MutateTransformer with AccelTraversal {
+
+
+  override def transform[A:Type](lhs: Sym[A], rhs: Op[A])(implicit ctx: SrcCtx): Sym[A] = rhs match {
+
+    case _:AccelScope => inAccel{ super.transform(lhs,rhs) }
+
+    case FixNeg(F(Op(LaneStatic(iter, elems)))) =>              
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(_ * -1)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+    case FixAdd(F(Final(a)), F(Op(LaneStatic(iter, elems)))) => 
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(_ +  a)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+    case FixAdd(F(Op(LaneStatic(iter, elems))), F(Final(a))) => 
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(_ +  a)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+    case FixSub(F(Final(a)), F(Op(LaneStatic(iter, elems)))) => 
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(a -  _)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+    case FixSub(F(Op(LaneStatic(iter, elems))), F(Final(a))) => 
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(_ -  a)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+    case FixMul(F(Final(a)), F(Op(LaneStatic(iter, elems)))) => 
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(_ *  a)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+    case FixMul(F(Op(LaneStatic(iter, elems))), F(Final(a))) => 
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(_ *  a)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+    case FixSLA(F(Op(LaneStatic(iter, elems))), F(Final(a))) => 
+      stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], elems.map(_ *  scala.math.pow(2,a).toInt)) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+
+    case FixMod(F(x), F(Final(y))) if inHw => 
+      val (iter, add, mul) = x match {
+        case Op(FixAdd(F(xx), Final(ofs))) => (xx, ofs, 1)
+        case Op(FixAdd(Final(ofs), F(xx))) => (xx, ofs, 1)
+        case Op(FixSub(F(xx), Final(ofs))) => (xx, -ofs, 1)
+        case Op(FixMul(Final(lin), F(xx))) => (xx, 0, lin)
+        case Op(FixMul(F(xx), Final(lin))) => (xx, 0, lin)
+        case Op(FixFMA(Final(lin), F(xx), Final(ofs))) => (xx, ofs, lin)
+        case Op(FixFMA(F(xx), Final(lin), Final(ofs))) => (xx, ofs, lin)
+        case _ => (x, 0, 1)
+      }
+
+      if (iter.getCounter.isDefined && iter.counter.lanes.size > 1 && staticMod(mul, iter, y)) {
+        // Convert FixMod node into a LaneStatic vector
+        val posMod = getPosMod(mul, iter, add, y)
+        // implicit val A: Bits[A] = iter.selfType
+        stageWithFlow( LaneStatic[FixPt[TRUE,_32,_0]](iter.asInstanceOf[FixPt[TRUE,_32,_0]], posMod) ){lhs2 => transferData(lhs, lhs2) }.asInstanceOf[Sym[A]]
+      } else super.transform(lhs,rhs)
+
+    case _ => super.transform(lhs,rhs)
+  }
+
+}

--- a/src/spatial/traversal/BroadcastCleanup.scala
+++ b/src/spatial/traversal/BroadcastCleanup.scala
@@ -18,7 +18,6 @@ case class BroadcastCleanupAnalyzer(IR: State) extends AccelTraversal {
     case _:Control[_] if lhs.isInnerControl => 
       lhs.op.get.blocks.foreach{block =>
         block.stms.reverse.foreach{sym => 
-          println(s"visiting $sym")
           sym match {
             case Op(_: StatusReader[_]) => sym.isBroadcastAddr = false
             case Op(_: BankedEnqueue[_]) => 

--- a/src/spatial/traversal/MemoryAnalyzer.scala
+++ b/src/spatial/traversal/MemoryAnalyzer.scala
@@ -61,6 +61,7 @@ case class MemoryAnalyzer(IR: State)(implicit isl: ISL, areamodel: AreaEstimator
       emit(s"""<br><font size = "2">NStrictness:   ${conf.nStricts}</font>""")
       emit(s"""<br><font size = "2">AlphaStrictness:   ${conf.aStricts}</font>""")
       emit(s"""<br><font size = "2">DimensionDuplication: ${conf.dimensionDuplication}</font>""")
+      dbgs(s"schem info for $mem is ${conf.schemesInfo.toList}")
       conf.schemesInfo.toList.sortBy(_._1).foreach{case (inst, schemes) => 
         val (partialCost: Double, winningScheme) = schemes.map{scheme => 
           val cost = scheme._2.map(_._4.head).sum

--- a/src/spatial/traversal/MemoryAnalyzer.scala
+++ b/src/spatial/traversal/MemoryAnalyzer.scala
@@ -61,7 +61,6 @@ case class MemoryAnalyzer(IR: State)(implicit isl: ISL, areamodel: AreaEstimator
       emit(s"""<br><font size = "2">NStrictness:   ${conf.nStricts}</font>""")
       emit(s"""<br><font size = "2">AlphaStrictness:   ${conf.aStricts}</font>""")
       emit(s"""<br><font size = "2">DimensionDuplication: ${conf.dimensionDuplication}</font>""")
-      dbgs(s"schem info for $mem is ${conf.schemesInfo.toList}")
       conf.schemesInfo.toList.sortBy(_._1).foreach{case (inst, schemes) => 
         val (partialCost: Double, winningScheme) = schemes.map{scheme => 
           val cost = scheme._2.map(_._4.head).sum

--- a/src/spatial/traversal/banking/ExhaustiveBanking.scala
+++ b/src/spatial/traversal/banking/ExhaustiveBanking.scala
@@ -56,7 +56,7 @@ case class ExhaustiveBanking()(implicit IR: State, isl: ISL) extends BankingStra
 
     // Generate substitution rules for each iter for each uid.  Given iter and its uid, generate a rule to replace it with a new iter and an offset to include in the access patterns c column
     def generateSubstRules(accs: Set[Set[AccessMatrix]]): scala.collection.immutable.Map[(Idx,Seq[Int]),(Idx,Int)] = {
-      val toRewrite: Map[(Idx, Seq[Int]), Option[Int]] = if (mem.forceExplicitBanking) Map() else accs.flatten.map{a => dephasingIters(a,mem)}.flatten.toMap
+      val toRewrite: Map[(Idx, Seq[Int]), Option[Int]] = if (mem.forceExplicitBanking) Map() else accs.flatten.map{a => dephasingIters(a,Seq.fill(a.unroll.size)(0),mem)}.flatten.toMap
       toRewrite.map{
         case((i,addr),ofs) if (ofs.isDefined) => ((i,addr) -> (i,ofs.get))
         case((i,addr),ofs) if (!ofs.isDefined) => ((i,addr) -> (boundVar[I32],0))

--- a/src/spatial/traversal/banking/MemoryConfigurer.scala
+++ b/src/spatial/traversal/banking/MemoryConfigurer.scala
@@ -322,9 +322,10 @@ class MemoryConfigurer[+C[_]](mem: Mem[_,C], strategy: BankingStrategy)(implicit
       case(iter,i) if (substRules.contains(iter) && substRules(iter).isDefined) => 
         if (substRules(iter).get != 0) dbgs(s"      WARNING: ${a.access} {${a.unroll}} - ${b.access} {${b.unroll}} have totally lockstepped iterator, $iter, with offset ${substRules(iter).get}") 
         (iter -> (iter, substRules(iter).get))
-      case(iter,i) if (substRules.contains(iter) && !substRules(iter).isDefined) => 
+      case(iter,i) if (substRules.contains(iter) && !substRules(iter).isDefined && a.matrix.keys.contains(iter)) => 
         dbgs(s"      WARNING: ${a.access} {${a.unroll}} - ${b.access} {${b.unroll}} have totally dephased iterator, $iter")
-        (iter -> (boundVar[I32], 0))
+        return true
+        // (iter -> (boundVar[I32], 0))
     }.toMap
     val newa = a.substituteKeys(keyRules)
     newa.overlapsAddress(b)

--- a/src/spatial/util/math.scala
+++ b/src/spatial/util/math.scala
@@ -1,0 +1,86 @@
+package spatial.util
+
+import argon._
+import forge.tags._
+
+import spatial.lang._
+import spatial.node._
+import emul.ResidualGenerator._
+import spatial.metadata.bounds._
+import spatial.metadata.control._
+import spatial.metadata.memory._
+import spatial.metadata.types._
+import spatial.metadata.rewrites._
+import spatial.metadata.retiming._
+import spatial.metadata.math._
+
+import argon.node._
+
+import emul.FixedPoint
+import forge.tags.stateful
+
+import utils.math.{isPow2,log2,gcd}
+
+object math {
+  /** Convert mod of pow2 into FixAnd */
+  @stateful def selectMod[S,I,F](x: FixPt[S,I,F], y: Int): FixPt[S,I,F] = {
+    implicit val S: BOOL[S] = x.fmt.s
+    implicit val I: INT[I] = x.fmt.i
+    implicit val F: INT[F] = x.fmt.f
+    if (log2(y.toDouble) == 0) x.from(0)
+    // TODO: Consider making a node like case class BitRemap(data: Bits[_], remap: Seq[Int], outType: Bits[T]) that wouldn't add to retime latency
+    else x & (scala.math.pow(2,log2(y.toDouble))-1).to[Fix[S,I,F]] 
+  }
+
+  /** Convert mod to a constant value */
+  @stateful def constMod[S,I,F](x: FixPt[S,I,F], y: Seq[Int]): FixPt[S,I,F] = {
+    implicit val S: BOOL[S] = x.fmt.s
+    implicit val I: INT[I] = x.fmt.i
+    implicit val F: INT[F] = x.fmt.f
+    if (y.size==1) {
+      x.from(y.head)
+    } else {
+      val b = boundVar[FixPt[S,I,F]]
+      b.vecConst = y
+      b
+    }
+  }
+
+  @stateful def staticMod(lin: scala.Int, iter: Num[_], y: scala.Int): Boolean = {
+    if (iter.counter.ctr.isStaticStartAndStep) {
+      val Final(step) = iter.counter.ctr.step
+      val par = iter.counter.ctr.ctrPar.toInt
+      val g = gcd(par*step*lin,y)
+      if (g == 1) false // Residue set of lin % y is {0,1,...,y-1}
+      else if (g % y == 0) true // Residue set of lin % y is {0}
+      else false // Residue set of lin % y is {0, g, 2g, ..., y-g}
+    }
+    else false
+  }
+
+  @stateful def residual(lin: scala.Int, iter: Num[_], ofs: scala.Int, y: scala.Int): ResidualGenerator = {
+    if (iter.getCounter.isDefined && iter.counter.ctr.isStaticStartAndStep) {
+      val Final(start) = iter.counter.ctr.start
+      val Final(step) = iter.counter.ctr.step
+      val par = iter.counter.ctr.ctrPar.toInt
+      val lanes = iter.counter.lanes
+      if (y != 0) {
+        val A = gcd(par * step * lin, y)
+        val B = lanes.map { lane => (((start + ofs + lane * step * lin) % y) + y) % y }
+        dbgs(s"Residual Generator for lane $lanes with step $step, lin $lin and start $start + $ofs under mod $y = $A, $B")
+        ResidualGenerator(A, B, y)
+      } else {
+        val A = par * step * lin
+        val B = lanes.map { lane => start + ofs + lane * step * lin }
+        ResidualGenerator(A, B, y)
+      }
+    }
+    else ResidualGenerator(1, 0, y)
+  }
+
+  @stateful def getPosMod(lin: scala.Int, x: Num[_], ofs: scala.Int, mod: scala.Int): Seq[scala.Int] = {
+    val res = residual(lin, x, ofs, mod)
+    res.resolvesTo.get
+  }
+
+}

--- a/src/spatial/util/modeling.scala
+++ b/src/spatial/util/modeling.scala
@@ -20,6 +20,13 @@ import scala.collection.immutable.SortedSet
 
 object modeling {
 
+  def mutatingBounds(x: Sym[_], visited: Set[Sym[_]] = Set(), bounds: Set[Idx] = Set()): Set[Idx] = {
+    val (newBounds, toCheck) = x.inputs.partition(_.isBound)
+    val toCheckExpanded = toCheck.toSeq.map{y: Sym[_] => if (y.isMem) y.writers.toSeq else Seq(y)}.flatten.toSet diff visited
+    val nextBounds = bounds ++ newBounds.map(_.asInstanceOf[Idx])
+    toCheckExpanded.flatMap{y => mutatingBounds(y, visited ++ toCheckExpanded, nextBounds)}
+  }
+
   def consumersDfs(frontier: Set[Sym[_]], nodes: Set[Sym[_]], scope: Set[Sym[_]]): Set[Sym[_]] = frontier.flatMap{x: Sym[_] =>
     if (scope.contains(x) && !nodes.contains(x)) {
       consumersDfs(x.consumers, nodes + x, scope)

--- a/test/spatial/tests/compiler/InitiationIntervals.scala
+++ b/test/spatial/tests/compiler/InitiationIntervals.scala
@@ -410,7 +410,7 @@ import spatial.metadata.control._
     val out = DRAM[Int](1,N)
 
     Accel {
-      val sram = SRAM[Int](M,N).noduplicate.buffer
+      val sram = SRAM[Int](M,N).noduplicate.buffer.hierarchical
       Foreach(iters.value by 1) { _ => 
         Foreach(N by 1){j => sram(0,j) = j}
         Foreach(1 until M by 1, N by 1 par N/2){(i,j) =>  // II = 1 for par = 1 and then increases for higher pars

--- a/test/spatial/tests/feature/banking/BankLockstep.scala
+++ b/test/spatial/tests/feature/banking/BankLockstep.scala
@@ -18,8 +18,8 @@ import spatial.dsl._
     setMem(cols_dram, cols)
 
     Accel {
-      val dataInConfl = SRAM[Int](16,16)   // Should duplicate
-      val dataInNoConfl = SRAM[Int](16,16) // Should not duplicate
+      val dataInConfl = SRAM[Int](16,16)//.flat?   // Should duplicate
+      val dataInNoConfl = SRAM[Int](16,16)//.flat?  // Should not duplicate
       val dataOut = SRAM[Int](4,16,16).hierarchical     // Should bank N = 4
       val cols_todo = SRAM[Int](16).noduplicate
       cols_todo load cols_dram

--- a/test/spatial/tests/feature/banking/BankLockstep.scala
+++ b/test/spatial/tests/feature/banking/BankLockstep.scala
@@ -98,3 +98,76 @@ import spatial.dsl._
   }
 
 }
+
+@spatial class SynchronizedStartsTest extends SpatialTest {
+
+  def main(args: Array[String]): Unit = {
+    val dummy = ArgIn[Int]
+    setArg(dummy, 5)
+    val P1 = 2
+    val P2 = 2
+
+    Accel {
+      def fillSRAM(s: SRAM1[Int]): Unit = Foreach(s.size by 1){i => s(i) = i}
+
+      // All controllers are synchronized and happy
+      val sram1 = SRAM[Int](16*16)
+      fillSRAM(sram1)
+      'LAYERA.Foreach(16 by 1 par P1, 4 by 1){(a0, a1) => 
+        val start = a0 % P1
+        'LAYERB.Foreach(4 by 1, 4 by 1){(b0, b1) => 
+          'LAYERC_STAGE0.Foreach(4 by 1){_ => println(r"$dummy")}
+          'LAYERC_STAGE1.Foreach(16 by 1 par P2){c0 => println(r"${sram1(a0*16 + c0)}")}
+        }
+      }
+
+      // LAYERC_STAGE0 causes c0 to be non-synchronized (even if STAGE0 and STAGE1 were swapped, since LAYERB is a loop)
+      val sram2 = SRAM[Int](16*16)  // Must duplicate for each lane of LAYERA (P1 duplicates)
+      fillSRAM(sram2)
+      'LAYERA.Foreach(16 by 1 par P1, 4 by 1){(a0, a1) => 
+        val start = a0 % P1
+        'LAYERB.Foreach(4 by 1, 4 by 1){(b0, b1) => 
+          'LAYERC_STAGE0.Foreach(start until 4 by 1){_ => println(r"$dummy")}
+          'LAYERC_STAGE1.Foreach(16 by 1 par P2){c0 => println(r"${sram2(a0*16 + c0)}")}
+        }
+      }
+
+      // All controllers are synchronized.  Even though LAYERB has uid-variant runtime, LAYERA unrolls it as MoP
+      val sram3 = SRAM[Int](16*16)
+      fillSRAM(sram3)
+      'LAYERA.Foreach(16 by 1 par P1, 4 by 1){(a0, a1) => 
+        val start = a0 % P1
+        'LAYERB.Foreach(4 by 1, 4 + start by 1){(b0, b1) => 
+          'LAYERC_STAGE0.Foreach(4 by 1){_ => println(r"$dummy")}
+          'LAYERC_STAGE1.Foreach(16 by 1 par P2){c0 => println(r"${sram3(a0*16 + c0)}")}
+        }
+      }
+
+      // No controllers are synchronized, because LAYERA unrolls as PoM and LAYERB causes uid-variant runtime
+      val sram4 = SRAM[Int](16*16) // Must duplicate for each lane of LAYERA and LAYERC_STAGE1 (P1*P2 duplicates)
+      fillSRAM(sram4)
+      'LAYERA.Pipe.POM.Foreach(16 by 1 par P1, 4 by 1){(a0, a1) => 
+        val start = a0 % P1
+        'LAYERB.Foreach(4 by 1, 4 + start by 1){(b0, b1) => 
+          'LAYERC_STAGE0.Foreach(4 by 1){_ => println(r"$dummy")}
+          'LAYERC_STAGE1.Foreach(16 by 1 par P2){c0 => println(r"${sram4(a0*16 + c0)}")}
+        }
+      }
+
+      // All controllers are synchronized, but LAYERC_STAGE1 iters of uid(a0)=1 are offset by 1, because LAYERA unrolls as PoM and LAYERB causes uid-variant runtime
+      val sram5 = SRAM[Int](16*16)
+      fillSRAM(sram5)
+      'LAYERA.Foreach(16 by 1 par P1, 4 by 1){(a0, a1) => 
+        val start = a0 % P1
+        'LAYERB.Foreach(4 by 1, 4 by 1){(b0, b1) => 
+          'LAYERC_STAGE0.Foreach(4 by 1){_ => println(r"$dummy")}
+          'LAYERC_STAGE1.Foreach(start until 16 by 1 par P2){c0 => println(r"${sram5(a0*16 + c0)}")}
+        }
+      }
+
+
+    }
+
+    assert(true)
+  }
+}

--- a/test/spatial/tests/feature/banking/BankLockstep.scala
+++ b/test/spatial/tests/feature/banking/BankLockstep.scala
@@ -18,8 +18,8 @@ import spatial.dsl._
     setMem(cols_dram, cols)
 
     Accel {
-      val dataInConfl = SRAM[Int](16,16)   // Should bank N = 8
-      val dataInNoConfl = SRAM[Int](16,16) // Should duplicate (can't broadcast), N = 4 and 2
+      val dataInConfl = SRAM[Int](16,16)   // Should duplicate
+      val dataInNoConfl = SRAM[Int](16,16) // Should not duplicate
       val dataOut = SRAM[Int](4,16,16).hierarchical     // Should bank N = 4
       val cols_todo = SRAM[Int](16).noduplicate
       cols_todo load cols_dram
@@ -100,7 +100,7 @@ import spatial.dsl._
 }
 
 @spatial class SynchronizedStartsTest extends SpatialTest {
-
+  // sram2 and sram4 should have P2 duplicates.  All else should have 1
   def main(args: Array[String]): Unit = {
     val dummy = ArgIn[Int]
     setArg(dummy, 5)
@@ -132,12 +132,12 @@ import spatial.dsl._
         }
       }
 
-      // All controllers are synchronized.  Even though LAYERB has uid-variant runtime, LAYERA unrolls it as MoP
+      // All controllers are synchronized.  Even though LAYERB has uid-variant runtime, LAYERA unrolls it as MoP and variance is in outermost iter
       val sram3 = SRAM[Int](16*16)
       fillSRAM(sram3)
       'LAYERA.Foreach(16 by 1 par P1, 4 by 1){(a0, a1) => 
         val start = a0 % P1
-        'LAYERB.Foreach(4 by 1, 4 + start by 1){(b0, b1) => 
+        'LAYERB.Foreach(4 + start by 1, 4 by 1){(b0, b1) => 
           'LAYERC_STAGE0.Foreach(4 by 1){_ => println(r"$dummy")}
           'LAYERC_STAGE1.Foreach(16 by 1 par P2){c0 => println(r"${sram3(a0*16 + c0)}")}
         }
@@ -154,15 +154,13 @@ import spatial.dsl._
         }
       }
 
-      // All controllers are synchronized, but LAYERC_STAGE1 iters of uid(a0)=1 are offset by 1, because LAYERA unrolls as PoM and LAYERB causes uid-variant runtime
+      // All controllers are synchronized, but LAYERC_STAGE1 iters of uid(a0)=1 are offset by 1 (mop unrolling of LAYERA)
       val sram5 = SRAM[Int](16*16)
       fillSRAM(sram5)
       'LAYERA.Foreach(16 by 1 par P1, 4 by 1){(a0, a1) => 
         val start = a0 % P1
-        'LAYERB.Foreach(4 by 1, 4 by 1){(b0, b1) => 
-          'LAYERC_STAGE0.Foreach(4 by 1){_ => println(r"$dummy")}
-          'LAYERC_STAGE1.Foreach(start until 16 by 1 par P2){c0 => println(r"${sram5(a0*16 + c0)}")}
-        }
+        'LAYERC_STAGE0.Foreach(4 by 1){_ => println(r"$dummy")}
+        'LAYERC_STAGE1.Foreach(start until 16 by 1 par P2){c0 => println(r"${sram5(a0*16 + c0)}")}
       }
 
 

--- a/test/spatial/tests/feature/banking/ParFIFOLoad2.scala
+++ b/test/spatial/tests/feature/banking/ParFIFOLoad2.scala
@@ -13,6 +13,7 @@ import spatial.dsl._
 
 
   def parFifoLoad[T:Num](src1: Array[T], src2: Array[T], src3: Array[T], in: Int): T = {
+    println(s"REMEMBER: This app relies on the pipe binding transformer!")
 
     val P1 = 1 (16 -> 16)
 

--- a/test/spatial/tests/feature/banking/ScanLines.scala
+++ b/test/spatial/tests/feature/banking/ScanLines.scala
@@ -33,7 +33,7 @@ import spatial.dsl._
     setArg(iters, 4)
 
     Accel{
-      val grid_sram = SRAM[Int](ROWS,COLS).hierarchical.noduplicate
+      val grid_sram = SRAM[Int](ROWS,COLS).hierarchical
       grid_sram load grid_dram(0::ROWS, 0::COLS par par_load)
 
       Foreach(iters by 1) { iter =>

--- a/test/spatial/tests/feature/memories/linebuf/LineBuffers.scala
+++ b/test/spatial/tests/feature/memories/linebuf/LineBuffers.scala
@@ -5,6 +5,7 @@ import spatial.dsl._
 @spatial class LineBufs extends SpatialTest {
 
   def main(args: Array[String]): Unit = {
+    println(s"REMEMBER: This app relies on the pipe binding transformer!")
     val init_dram = DRAM[I32](10,24)
     val init = (0::10,0::24){(i,j) => i*24 + j}
     val last_dram = DRAM[I32](3,24)


### PR DESCRIPTION
Merge in refactoring of lockstep analysis.  "Synchronized start" is a less confusing term for it.  Basically we care about whether iterators from some uid0 will always increment in synchronized fashion with those same iterators from uid1.  If an outer controller is unrolled as PoM, you need to treat it as if the branch point is above that controller in the hierarchy.  If it is unrolled as MoP, you treat the branch point below that controller and you really only care about the synchronization of the particular child whose iterators you are going to look up next.  Also if you are looking at a "terminal" controller, then you don't care about the outermost iterator of a given counter chain because even though the two uid copies will finish at different times, their iterators will always increment together for the purposes of banking analysis.  If you are looking at a looping outer controller that exists somewhere underneath a pom or mop unroll, then you do need to consider all the sibling controllers and outermost iterators.