### PR TITLE
Added support to read a text file and dump to the device memory directly

### DIFF
--- a/apps/src/TextFileIO.scala
+++ b/apps/src/TextFileIO.scala
@@ -3,7 +3,8 @@ import spatial.dsl._
 // PASSED
 @spatial object TextFileIO extends SpatialApp {
   def main(args: Array[String]): Unit = {
-    val dataFname = "../../data/source.txt"
+    val dataDir = sys.env("DATA")
+    val dataFname = dataDir + "/sflow/sentiment_analysis/source.txt"
 
     val dramSrc = DRAM[Char](128)
     loadDRAMWithASCIIText[Char](dataFname, dramSrc)

--- a/apps/src/TextFileIO.scala
+++ b/apps/src/TextFileIO.scala
@@ -7,17 +7,16 @@ import spatial.dsl._
     val argOut = ArgOut[I32]
     val dataFname = "../../data/source.txt"
 
-    val testTextArray = loadASCIITextFile(dataFname)
-    val dramSrc = DRAM[Char](testTextArray.length)
-    setMem(dramSrc, testTextArray)
+    val dramSrc = DRAM[Char](128)
+    loadDRAMWithASCIIText[Char](dataFname, dramSrc)
     val dramOut = DRAM[Char](128.to[I32]) // Only load 32 chars for now and see what they look like...
+    setMem(dramOut, Array.tabulate[Char](128)(i => i.to[Char]))
 
     Accel {
       val mem = SRAM[Char](128.to[I32])
       mem load dramSrc(0::128)
       dramOut(0::128) store mem
     }
-
 
     println(argOut.value)
     printArray(getMem(dramOut))

--- a/apps/src/TextFileIO.scala
+++ b/apps/src/TextFileIO.scala
@@ -1,0 +1,25 @@
+import spatial.dsl._
+
+// PASSED
+@spatial object TextFileIO extends SpatialApp {
+  def main(args: Array[String]): Unit = {
+    val testLen = 128
+    val argOut = ArgOut[I32]
+    val dataFname = "../../data/source.txt"
+
+    val testTextArray = loadASCIITextFile(dataFname)
+    val dramSrc = DRAM[Char](testTextArray.length)
+    setMem(dramSrc, testTextArray)
+    val dramOut = DRAM[Char](128.to[I32]) // Only load 32 chars for now and see what they look like...
+
+    Accel {
+      val mem = SRAM[Char](128.to[I32])
+      mem load dramSrc(0::128)
+      dramOut(0::128) store mem
+    }
+
+
+    println(argOut.value)
+    printArray(getMem(dramOut))
+  }
+}

--- a/apps/src/TextFileIO.scala
+++ b/apps/src/TextFileIO.scala
@@ -3,8 +3,6 @@ import spatial.dsl._
 // PASSED
 @spatial object TextFileIO extends SpatialApp {
   def main(args: Array[String]): Unit = {
-    val testLen = 128
-    val argOut = ArgOut[I32]
     val dataFname = "../../data/source.txt"
 
     val dramSrc = DRAM[Char](128)
@@ -18,7 +16,6 @@ import spatial.dsl._
       dramOut(0::128) store mem
     }
 
-    println(argOut.value)
     printArray(getMem(dramOut))
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,9 @@ val base = Seq(
     "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
     "com.github.pureconfig" %% "pureconfig" % "0.9.2",
     "org.jpmml" % "pmml-evaluator" % "1.4.8",
-    "org.scalanlp" %% "breeze" % "1.0"
+    "org.scalanlp" %% "breeze" % "1.0",
+    "javax.xml.bind" % "jaxb-api" % "2.3.0"
+
     // "com.thoughtworks.xstream" % "xstream" % "1.4.3",
     // These are a bit bulky, leaving them out in favor of a stripped down version for now
     //"org.apache.commons" % "commons-lang3" % "3.3.2",
@@ -167,7 +169,7 @@ lazy val test = project.settings(
   common ++ Seq(scalaSource in Test := baseDirectory.in(spatial).value/"test"),
 ).dependsOn(spatial)
 
-lazy val pirTest = project 
+lazy val pirTest = project
 .settings(common)
 .settings(
   scalaSource in Test := baseDirectory.in(spatial).value/"pir/regression"

--- a/data/source.txt
+++ b/data/source.txt
@@ -1,4 +1,0 @@
-This is a first test of the sentiment analyzer.
-Test 2 is about tokenizing simple things.
-Test 3 is going on.
-Hopefully I should be able to get a good performance out of this.

--- a/data/source.txt
+++ b/data/source.txt
@@ -1,0 +1,4 @@
+This is a first test of the sentiment analyzer.
+Test 2 is about tokenizing simple things.
+Test 3 is going on.
+Hopefully I should be able to get a good performance out of this.

--- a/src/spatial/codegen/cppgen/CppGenFileIO.scala
+++ b/src/spatial/codegen/cppgen/CppGenFileIO.scala
@@ -16,7 +16,7 @@ trait CppGenFileIO extends CppGenCommon {
       // Pull raw data out of file
       emit(src"${file}.seekg(0, std::ios::end);")
       emit(src"""std::ifstream::pos_type ${lhs}_pos = ${file}.tellg();""")
-      emit(src"std::vector<char> ${lhs}_temp (${lhs}_pos); ")
+      emit(src"std::vector<char> ${lhs}_temp (${lhs}_pos); ") // TODO: need to new this thing.
       emit(src"${file}.seekg(0, std::ios::beg);")
       emit(src"${file}.read(&${lhs}_temp[0], ${lhs}_pos);")
       val chars = Math.ceil(op.A.nbits.toDouble / 8).toInt
@@ -25,7 +25,7 @@ trait CppGenFileIO extends CppGenCommon {
       // Avoid double allocating vectors when the binary file is a large text file
       if (isASCIITextFile) {
         emit(
-          src"${lhs.tp}* ${lhs} = ${lhs}_temp;"
+          src"vector<char>* ${lhs} = &${lhs}_temp;"
         )
       } else {
         // Place raw data in appropriately-sized vector with correct bit width

--- a/src/spatial/codegen/cppgen/CppGenFileIO.scala
+++ b/src/spatial/codegen/cppgen/CppGenFileIO.scala
@@ -7,16 +7,28 @@ import spatial.node._
 trait CppGenFileIO extends CppGenCommon {
 
   override protected def gen(lhs: Sym[_], rhs: Op[_]): Unit = rhs match {
-    case op @ LoadDRAMWithASCIIText(file, dram) =>
-      emit(src"${file}.seekg(0, std::ios::end);")
-      emit(src"""std::ifstream::pos_type ${lhs}_pos = ${file}.tellg();""")
-      emit(src"std::vector<char> ${lhs}_temp = new std::vector((${lhs}_pos)); ")
-      emit(src"${file}.seekg(0, std::ios::beg);")
-      emit(src"${file}.read(${lhs}_temp[0], ${lhs}_pos);")
-
-      val chars = Math.ceil(op.A.nbits.toDouble / 8).toInt
-      val rawtp = asIntType(op.A)
-      emit(src"I'm here...")
+    case op @ LoadDRAMWithASCIIText(dram, file) =>
+      emit(
+        src"${file}.seekg(0, std::ios::end);"
+      )
+      emit(
+        src"""std::ifstream::pos_type ${lhs}_pos = ${file}.tellg();"""
+      )
+      emit(
+        src"char* ${lhs}_temp = (char *) malloc(${lhs}_pos * sizeof(char));"
+      )
+      emit(
+        src"${file}.seekg(0, std::ios::beg);"
+      )
+      emit(
+        src"${file}.read(&${lhs}_temp[0], ${lhs}_pos);"
+      )
+      emit(
+        src"c1->memcpy($dram, &${lhs}_temp[0], ${lhs}_pos * sizeof(char));"
+      )
+      emit(
+        src"free(${lhs}_temp);"
+      )
 //      emit(src"memcpy((void*)&((*${lhs}_raw)[0]), &(${lhs}_temp[0]), ${lhs}_temp.size() * sizeof(char));")
 //      emit(src"c1->memcpy($dram, &(*$ptr)[0], (*$ptr).size() * sizeof(${rawtp}));")
 

--- a/src/spatial/codegen/scalagen/ScalaGenFileIO.scala
+++ b/src/spatial/codegen/scalagen/ScalaGenFileIO.scala
@@ -51,7 +51,7 @@ trait ScalaGenFileIO extends ScalaCodegen {
 
     case OpenBinaryFile(filename, write) => emit(src"val $lhs = $filename")
 
-    case op @ ReadBinaryFile(file, _) =>
+    case op @ ReadBinaryFile(file) =>
       open(src"val $lhs = {")
         emit(src"val filepath = java.nio.file.Paths.get($file)")
         emit(src"val buffer = java.nio.file.Files.readAllBytes(filepath)")

--- a/src/spatial/codegen/scalagen/ScalaGenFileIO.scala
+++ b/src/spatial/codegen/scalagen/ScalaGenFileIO.scala
@@ -48,6 +48,21 @@ trait ScalaGenFileIO extends ScalaCodegen {
         emit(src"writer.close()")
       close("}")
 
+    case LoadDRAMWithASCIIText(dram, filename) =>
+      open(src"val $lhs = {")
+        emit(src"val filepath = java.nio.file.Paths.get($filename)")
+        emit(src"val buffer = java.nio.file.Files.readAllBytes(filepath)")
+        emit(src"val bb = java.nio.ByteBuffer.wrap(buffer)")
+        emit(src"bb.order(java.nio.ByteOrder.nativeOrder)")
+        emit(src"val array = bb.array")
+
+        open(s"array.sliding(1, 1).toArray.map{x => ")
+          emit(src"FixedPoint.fromByteArray(x, FixFormat(false, 8, 0))")
+        close("}")
+      close("}")
+      open(src"for (i <- 0 until ${lhs}.length) {")
+        emit(src"$dram(i) = ${lhs}(i)")
+      close("}")
 
     case OpenBinaryFile(filename, write) => emit(src"val $lhs = $filename")
 

--- a/src/spatial/codegen/scalagen/ScalaGenFileIO.scala
+++ b/src/spatial/codegen/scalagen/ScalaGenFileIO.scala
@@ -51,7 +51,7 @@ trait ScalaGenFileIO extends ScalaCodegen {
 
     case OpenBinaryFile(filename, write) => emit(src"val $lhs = $filename")
 
-    case op @ ReadBinaryFile(file) =>
+    case op @ ReadBinaryFile(file, _) =>
       open(src"val $lhs = {")
         emit(src"val filepath = java.nio.file.Paths.get($file)")
         emit(src"val buffer = java.nio.file.Files.readAllBytes(filepath)")

--- a/src/spatial/lang/api/FileIOAPI.scala
+++ b/src/spatial/lang/api/FileIOAPI.scala
@@ -96,7 +96,7 @@ trait FileIOAPI { this: Implicits =>
   }
 
   @rig def openBinary(filename: Text, write: Boolean): BinaryFile = stage(OpenBinaryFile(filename, write))
-  @rig def readBinary[A:Num](file: BinaryFile, isASCIITextFile: Boolean = false): Tensor1[A] = stage(ReadBinaryFile(file, isASCIITextFile))
+  @rig def readBinary[A:Num](file: BinaryFile, isASCIITextFile: Boolean = false): Tensor1[A] = stage(ReadBinaryFile(file))
   @rig def writeBinary[A:Num](file: BinaryFile, len: I32)(func: I32 => A): Void = {
     val i = boundVar[I32]
     val f = stageLambda1(i){ func(i) }
@@ -126,11 +126,12 @@ trait FileIOAPI { this: Implicits =>
   @api def loadNumpy2D[T:Num](name: String): Tensor2[T] = stage(NumpyMatrix(name))
 
 
-  /** Loads an ASCII text file. */
-  @api def loadASCIITextFile(filename: Text): Tensor1[spatial.dsl.Char] = {
+  /** Returns a 1-D DRAM preloaded with a raw text file.
+    * We assume that the text file is sufficiently large.
+    * Hence, we cannot */
+  @api def loadDRAMWithASCIIText[T:Num](filename: Text, dram: DRAM1[T]): Void = {
     val file = openBinary(filename, write = false)
-    val array = readBinary[spatial.dsl.Char](file, isASCIITextFile = true)
+    stage(LoadDRAMWithASCIIText(file, dram))
     closeBinary(file)
-    array
   }
 }

--- a/src/spatial/lang/api/FileIOAPI.scala
+++ b/src/spatial/lang/api/FileIOAPI.scala
@@ -131,7 +131,7 @@ trait FileIOAPI { this: Implicits =>
     * Hence, we cannot */
   @api def loadDRAMWithASCIIText[T:Num](filename: Text, dram: DRAM1[T]): Void = {
     val file = openBinary(filename, write = false)
-    stage(LoadDRAMWithASCIIText(file, dram))
+    stage(LoadDRAMWithASCIIText(dram, file))
     closeBinary(file)
   }
 }

--- a/src/spatial/lang/api/FileIOAPI.scala
+++ b/src/spatial/lang/api/FileIOAPI.scala
@@ -96,15 +96,13 @@ trait FileIOAPI { this: Implicits =>
   }
 
   @rig def openBinary(filename: Text, write: Boolean): BinaryFile = stage(OpenBinaryFile(filename, write))
-  @rig def readBinary[A:Num](file: BinaryFile): Tensor1[A] = stage(ReadBinaryFile(file))
+  @rig def readBinary[A:Num](file: BinaryFile, isASCIITextFile: Boolean = false): Tensor1[A] = stage(ReadBinaryFile(file, isASCIITextFile))
   @rig def writeBinary[A:Num](file: BinaryFile, len: I32)(func: I32 => A): Void = {
     val i = boundVar[I32]
     val f = stageLambda1(i){ func(i) }
     stage(WriteBinaryFile(file, len, f))
   }
   @rig def closeBinary(file: BinaryFile): Void = stage(CloseBinaryFile(file))
-
-
 
   /** Loads the given binary file at `filename` as an Array. */
   @api def loadBinary[T:Num](filename: Text): Tensor1[T] = {
@@ -127,4 +125,12 @@ trait FileIOAPI { this: Implicits =>
   /** Creates a placeholder for a numpy matrix as an @Tensor2.**/
   @api def loadNumpy2D[T:Num](name: String): Tensor2[T] = stage(NumpyMatrix(name))
 
+
+  /** Loads an ASCII text file. */
+  @api def loadASCIITextFile(filename: Text): Tensor1[spatial.dsl.Char] = {
+    val file = openBinary(filename, write = false)
+    val array = readBinary[spatial.dsl.Char](file, isASCIITextFile = true)
+    closeBinary(file)
+    array
+  }
 }

--- a/src/spatial/node/FileIO.scala
+++ b/src/spatial/node/FileIO.scala
@@ -34,7 +34,7 @@ import spatial.lang._
   override def effects: Effects = Effects.Writes(file)
 }
 
-@op case class ReadBinaryFile[A:Num](file: BinaryFile) extends Op2[A,Tensor1[A]] {
+@op case class ReadBinaryFile[A:Num](file: BinaryFile, isASCIITextFile: Boolean = false) extends Op2[A,Tensor1[A]] {
   override val A: Num[A] = Num[A]
 }
 

--- a/src/spatial/node/FileIO.scala
+++ b/src/spatial/node/FileIO.scala
@@ -34,7 +34,7 @@ import spatial.lang._
   override def effects: Effects = Effects.Writes(file)
 }
 
-@op case class ReadBinaryFile[A:Num](file: BinaryFile, isASCIITextFile: Boolean = false) extends Op2[A,Tensor1[A]] {
+@op case class ReadBinaryFile[A:Num](file: BinaryFile) extends Op2[A,Tensor1[A]] {
   override val A: Num[A] = Num[A]
 }
 
@@ -48,8 +48,12 @@ import spatial.lang._
   override def binds = super.binds + value.input
 }
 
-
 @op case class NumpyArray[A:Type](v: String) extends Op[Tensor1[A]]
 
 @op case class NumpyMatrix[A:Type](v: String) extends Op[Tensor2[A]]
 
+@op case class LoadDRAMWithASCIIText[A:Bits, C[T]](file: BinaryFile, dram: DRAM[A, C])
+  extends Op2[A, Void] {
+  override val A: Bits[A] = Bits[A]
+  override def effects: Effects = Effects.Sticky
+}

--- a/src/spatial/node/FileIO.scala
+++ b/src/spatial/node/FileIO.scala
@@ -52,8 +52,8 @@ import spatial.lang._
 
 @op case class NumpyMatrix[A:Type](v: String) extends Op[Tensor2[A]]
 
-@op case class LoadDRAMWithASCIIText[A:Bits, C[T]](file: BinaryFile, dram: DRAM[A, C])
+@op case class LoadDRAMWithASCIIText[A:Bits, C[T]](dram: DRAM[A, C], file: BinaryFile)
   extends Op2[A, Void] {
   override val A: Bits[A] = Bits[A]
-  override def effects: Effects = Effects.Sticky
+  override def effects: Effects = Effects.Writes(dram)
 }


### PR DESCRIPTION
**Problem description**: The existing way to load a text file into device memory is to first create a DRAM, load a file into an Array, and then setMem(...). In the case where the text file is large, e.g., text processing where a file can be >100MB, doing so leads to allocating large byte arrays on the host's stack that could cause a stack overflow. 
**Fix in this pull request**: I added a new node, loadDRAMWithASCIIText. At the host side, we don't create an Array on the stack; instead, we allocated it on the heap and delete it after memcpy-ing to the device memory. 
**Usage**: apps/src/TextFileIO.scala
**Others**: Spatial's build.sbt could not support later versions of Java due to a bug in javax XML parser. I added one line in build.sbt to solve this issue. 