### PR TITLE
Moves scoping information into an explicit stack

### DIFF
--- a/argon/src/argon/DSLRunnable.scala
+++ b/argon/src/argon/DSLRunnable.scala
@@ -15,7 +15,7 @@ trait DSLRunnable { self =>
     state.config.genDir = s"$cwd/gen/$name/"
     state.config.repDir = s"$cwd/reports/$name/"
     state.config.setV(1)
-    state.newScope(motion=false)  // Start a new scope (allows global declarations)
+    state.init()  // Start a new scope (allows global declarations)
     state
   }
 

--- a/argon/src/argon/DSLTest.scala
+++ b/argon/src/argon/DSLTest.scala
@@ -258,7 +258,7 @@ trait DSLTest extends Testbench with Compiler with Args { test =>
     run  = "",
     model = ""
   ) {
-    def shouldRun: Boolean = true
+    override def shouldRun: Boolean = true
     override def runBackend(): Unit = {
       s"${test.name}" should s"have $errors compiler errors" in {
         compile(expectErrors = true).foreach{err =>
@@ -280,7 +280,7 @@ trait DSLTest extends Testbench with Compiler with Args { test =>
     run  = "",
     model = ""
   ) {
-    def shouldRun: Boolean = true
+    override def shouldRun: Boolean = true
     override def runBackend(): Unit = ignore should "compile, run, and verify" in { () }
   }
 

--- a/src/spatial/SpatialTest.scala
+++ b/src/spatial/SpatialTest.scala
@@ -37,7 +37,7 @@ trait SpatialTest extends Spatial with DSLTest with PlasticineTest { self =>
     run  = "bash scripts/regression_run.sh scalasim",
     model = "noninteractive"
   ) {
-    def shouldRun: Boolean = checkFlag("test.Scala")
+    override def shouldRun: Boolean = checkFlag("test.Scala")
     override def parseRunError(line: String): Result = {
       if (line.trim.startsWith("at")) RunError(prev) // Scala exception
       else if (line.trim.contains("Assertion failure")) RunError(line) // Assertion failure


### PR DESCRIPTION
This should enable metaprogrammed applications to "escape" the inner scope at stage at a higher scope by saving the scope index of the parent and replacing the current scope with the parent scope when necessary.

For non-metaprogrammed applications there should be no functional change.